### PR TITLE
feat(scorecard): ER/KG success scorecard page (#403)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import PipelinePage from './pages/pipeline/PipelinePage';
 import SettingsPage from './pages/settings/SettingsPage';
 import ApisPage from './pages/apis/ApisPage';
 import EmailsPage from './pages/emails/EmailsPage';
+import ScorecardPage from './pages/scorecard/ScorecardPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -42,6 +43,7 @@ export default function App() {
               <Route path="worker" element={<WorkerPage />} />
               <Route path="moderation" element={<ModerationPage />} />
               <Route path="quality" element={<QualityPage />} />
+              <Route path="scorecard" element={<ScorecardPage />} />
               <Route path="pipeline" element={<PipelinePage />} />
               <Route path="apis" element={<ApisPage />} />
               <Route path="emails" element={<EmailsPage />} />

--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -183,6 +183,40 @@ export function useResolutionMetrics() {
   });
 }
 
+// --- ER / KG scorecard (epic #395) ---
+export function useDeduplicationEffectiveness() {
+  return useQuery({
+    queryKey: ['metrics', 'deduplication-effectiveness'],
+    queryFn: () => client.get('/metrics/deduplication/effectiveness').then(r => r.data),
+    staleTime: 60_000,
+  });
+}
+
+export function useQualityTrends() {
+  return useQuery({
+    queryKey: ['metrics', 'quality-trends'],
+    queryFn: () => client.get('/metrics/quality-trends').then(r => r.data),
+    staleTime: 60_000,
+  });
+}
+
+export function useLowQualityThings({ limit = 50, threshold = 0.5 } = {}) {
+  return useQuery({
+    queryKey: ['metrics', 'low-quality-things', limit, threshold],
+    queryFn: () =>
+      client.get('/metrics/low-quality-things', { params: { limit, threshold } }).then(r => r.data),
+    staleTime: 60_000,
+  });
+}
+
+export function useWorkRollup() {
+  return useQuery({
+    queryKey: ['metrics', 'work-rollup'],
+    queryFn: () => client.get('/metrics/work-rollup').then(r => r.data),
+    staleTime: 60_000,
+  });
+}
+
 // --- Type Rules ---
 export function useTypeRules() {
   return useQuery({

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -12,6 +12,7 @@ const NAV_SECTIONS = [
     label: 'Registry',
     items: [
       { to: '/seeding', label: 'Seeding' },
+      { to: '/scorecard', label: 'ER/KG Scorecard' },
     ],
   },
   {

--- a/src/components/Sparkline.jsx
+++ b/src/components/Sparkline.jsx
@@ -1,0 +1,25 @@
+export default function Sparkline({ values, color = '#6366f1', width = 120, height = 28 }) {
+  const series = (values || []).filter(v => typeof v === 'number' && !Number.isNaN(v));
+  if (series.length < 2) {
+    return <span className="text-xs text-gray-300">—</span>;
+  }
+  const max = Math.max(...series, 1);
+  const min = Math.min(...series, 0);
+  const range = max - min || 1;
+  const step = width / (series.length - 1);
+  const points = series
+    .map((v, i) => `${(i * step).toFixed(1)},${(height - ((v - min) / range) * height).toFixed(1)}`)
+    .join(' ');
+  return (
+    <svg width={width} height={height} className="overflow-visible">
+      <polyline
+        points={points}
+        fill="none"
+        stroke={color}
+        strokeWidth="1.5"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}

--- a/src/pages/scorecard/ScorecardPage.jsx
+++ b/src/pages/scorecard/ScorecardPage.jsx
@@ -1,0 +1,320 @@
+import PageHeader from '../../components/PageHeader';
+import Sparkline from '../../components/Sparkline';
+import {
+  useQualitySummary,
+  useSeedStatus,
+  useDeduplicationEffectiveness,
+  useQualityTrends,
+  useWorkRollup,
+} from '../../api/hooks';
+import { BASELINE, BASELINE_DATE } from './baseline';
+
+const ISSUE_URL = 'https://github.com/tnats/listgem-platform/issues';
+
+// --- formatting -----------------------------------------------------------
+function fmt(value, format) {
+  if (value == null || Number.isNaN(value)) return '—';
+  if (format === 'pct') return `${value.toFixed(1)}%`;
+  if (format === 'score') return value.toFixed(3);
+  return Math.round(value).toLocaleString();
+}
+
+function deltaLabel(diff, format) {
+  const sign = diff > 0 ? '+' : '';
+  if (format === 'pct') return `${sign}${diff.toFixed(1)} pts`;
+  if (format === 'score') return `${sign}${diff.toFixed(3)}`;
+  return `${sign}${Math.round(diff).toLocaleString()}`;
+}
+
+function Delta({ current, baseline, higherIsBetter, format }) {
+  if (current == null || baseline == null || Number.isNaN(current)) return null;
+  const diff = current - baseline;
+  const negligible = format === 'score' ? Math.abs(diff) < 0.001 : Math.abs(diff) < 0.05;
+  let cls = 'text-gray-400 bg-gray-50';
+  if (!negligible) {
+    const improved = higherIsBetter ? diff > 0 : diff < 0;
+    cls = improved ? 'text-green-700 bg-green-50' : 'text-red-700 bg-red-50';
+  }
+  return (
+    <span className={`text-xs font-medium px-1.5 py-0.5 rounded tabular-nums ${cls}`}>
+      {negligible ? '±0' : deltaLabel(diff, format)}
+    </span>
+  );
+}
+
+// --- tiles ----------------------------------------------------------------
+function MetricTile({ label, current, baseline, format, higherIsBetter, sparkline, color }) {
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 flex flex-col">
+      <div className="text-sm text-gray-500">{label}</div>
+      <div className="mt-1 flex items-baseline gap-2">
+        <span className="text-2xl font-semibold text-gray-900 tabular-nums">
+          {fmt(current, format)}
+        </span>
+        <Delta current={current} baseline={baseline} higherIsBetter={higherIsBetter} format={format} />
+      </div>
+      <div className="mt-auto pt-3 flex items-end justify-between">
+        <span className="text-xs text-gray-400">
+          baseline <span className="tabular-nums text-gray-500">{fmt(baseline, format)}</span>
+        </span>
+        <Sparkline values={sparkline} color={color || '#6366f1'} />
+      </div>
+    </div>
+  );
+}
+
+function StubTile({ label, baseline, format, pendingIssue }) {
+  return (
+    <div className="bg-white rounded-lg border border-dashed border-gray-200 p-4 flex flex-col">
+      <div className="flex items-start justify-between gap-2">
+        <div className="text-sm text-gray-500">{label}</div>
+        <a
+          href={`${ISSUE_URL}/${pendingIssue.replace('#', '')}`}
+          target="_blank"
+          rel="noreferrer"
+          className="shrink-0 text-xs font-medium text-amber-700 bg-amber-50 px-1.5 py-0.5 rounded hover:bg-amber-100"
+        >
+          pending {pendingIssue}
+        </a>
+      </div>
+      <div className="mt-1 text-2xl font-semibold text-gray-300 tabular-nums">—</div>
+      <div className="mt-auto pt-3 text-xs text-gray-400">
+        baseline <span className="tabular-nums text-gray-500">{fmt(baseline, format)}</span>
+      </div>
+    </div>
+  );
+}
+
+// --- Work-rollup readiness (issue #403 comment · keystone #396 flag) ------
+const READINESS = {
+  latent: { label: 'Latent', cls: 'text-gray-600 bg-gray-100' },
+  emerging: { label: 'Emerging', cls: 'text-amber-700 bg-amber-100' },
+  ready: { label: 'Ready', cls: 'text-green-700 bg-green-100' },
+};
+
+function MiniStat({ label, value }) {
+  return (
+    <div className="bg-gray-50 rounded p-3">
+      <div className="text-xl font-semibold text-gray-900 tabular-nums">
+        {value == null ? '—' : Number(value).toLocaleString()}
+      </div>
+      <div className="mt-0.5 text-xs text-gray-500">{label}</div>
+    </div>
+  );
+}
+
+function WorkRollupPanel({ query }) {
+  const d = query.data;
+  const unavailable = query.isError || (d && d.available === false);
+
+  // Endpoint ships live after the next backend deploy — degrade gracefully.
+  if (query.isLoading || unavailable) {
+    return (
+      <div className="mb-6 bg-white rounded-lg border border-dashed border-gray-200 p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium text-gray-700">Work-rollup readiness</h2>
+          <span className="text-xs font-medium text-amber-700 bg-amber-50 px-1.5 py-0.5 rounded">
+            {query.isLoading ? 'loading…' : 'awaiting deploy'}
+          </span>
+        </div>
+        <p className="mt-2 text-xs text-gray-400">
+          “Is it time to flip <code>WORK_LEVEL_CONSENSUS</code>?” — live once
+          <code> /metrics/work-rollup</code> deploys.
+        </p>
+      </div>
+    );
+  }
+
+  const r = READINESS[d.readiness] || { label: d.readiness || 'Unknown', cls: 'text-gray-600 bg-gray-100' };
+  const curation = d.curation_signal || {};
+  const delta = d.rollup_delta || {};
+  const flag = d.flag || {};
+
+  return (
+    <div className="mb-6 bg-white rounded-lg border border-gray-200 p-4">
+      <div className="flex items-center justify-between gap-3">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-medium text-gray-700">Work-rollup readiness</h2>
+          <span className={`text-xs font-semibold px-2 py-0.5 rounded ${r.cls}`}>{r.label}</span>
+        </div>
+        <span
+          className={`text-xs font-medium px-2 py-0.5 rounded ${
+            flag.enabled ? 'text-green-700 bg-green-50' : 'text-gray-500 bg-gray-100'
+          }`}
+        >
+          {flag.name || 'WORK_LEVEL_CONSENSUS'} {flag.enabled ? 'ON' : 'OFF'}
+        </span>
+      </div>
+
+      {d.message && <p className="mt-2 text-sm text-gray-600">{d.message}</p>}
+
+      <div className="mt-4 grid grid-cols-3 gap-3">
+        <MiniStat label="Works with 2+ curated editions" value={curation.works_with_2plus_editions_curated} />
+        <MiniStat label="Ranking merges if flipped (delta)" value={delta.ranked_delta} />
+        <MiniStat label="Representatives changed" value={delta.representatives_changed} />
+      </div>
+    </div>
+  );
+}
+
+// --- data extraction (defensive — backend shapes may vary) ----------------
+function numberOrNull(...candidates) {
+  for (const c of candidates) {
+    const n = typeof c === 'string' ? parseFloat(c) : c;
+    if (typeof n === 'number' && !Number.isNaN(n)) return n;
+  }
+  return null;
+}
+
+export default function ScorecardPage() {
+  const quality = useQualitySummary();
+  const seed = useSeedStatus();
+  const dedup = useDeduplicationEffectiveness();
+  const trends = useQualityTrends();
+  const workRollup = useWorkRollup();
+
+  const overall = quality.data?.overall || {};
+  const distribution = quality.data?.distribution || [];
+  const seedData = seed.data || {};
+  const dedupData = dedup.data || {};
+
+  // Registry size
+  const registryThings = numberOrNull(
+    seedData.total_things,
+    overall.total_things,
+  );
+
+  // Canonical-ID coverage (any) — backend key not yet firm; try a few shapes.
+  const canonicalAnyPct = numberOrNull(
+    dedupData.canonical_id_coverage_pct,
+    dedupData.canonical_coverage_pct,
+    dedupData.coverage_pct,
+    dedupData.canonical_id_any_pct,
+  );
+
+  // Extraction quality average (0..1)
+  const extractionAvg = numberOrNull(overall.avg_quality);
+
+  // Low-quality tail (% below 0.5) — derive from the quality distribution.
+  const totalForTail = numberOrNull(overall.total_things);
+  const lowQualityCount = distribution
+    .filter(t => t.quality_tier === 'poor' || t.quality_tier === 'unusable')
+    .reduce((s, t) => s + (parseInt(t.count) || 0), 0);
+  const lowQualityPct =
+    totalForTail && totalForTail > 0 ? (lowQualityCount / totalForTail) * 100 : null;
+
+  // Trend sparklines (best-effort against the quality-trends shape).
+  const trendRows = [...(trends.data?.trends || trends.data?.daily || [])].sort(
+    (a, b) => new Date(a.day || a.date) - new Date(b.day || b.date),
+  );
+  const qualityTrend = trendRows
+    .map(r => numberOrNull(r.avg_quality, r.avg))
+    .filter(v => v != null);
+  const lowQualityTrend = trendRows
+    .map(r => numberOrNull(r.low_quality_pct, r.below_threshold_pct))
+    .filter(v => v != null);
+
+  const isLoading = quality.isLoading && seed.isLoading;
+  const liveError = quality.error || seed.error;
+
+  return (
+    <>
+      <PageHeader
+        title="ER/KG Scorecard"
+        description={`Measuring the entity-resolution epic (#395) against the frozen ${BASELINE_DATE} baseline — baseline · current · delta · trend.`}
+      />
+
+      <div className="mb-4 p-3 rounded border border-indigo-100 bg-indigo-50 text-xs text-indigo-800">
+        Live tiles wire the existing <code>/metrics/*</code> endpoints; pending tiles are stubbed
+        against their child issue. Trends render from live endpoints today — weekly-snapshot
+        persistence (for full historical trends) is a backend follow-up to #403.
+      </div>
+
+      {liveError && (
+        <div className="mb-4 p-3 rounded border border-red-200 bg-red-50 text-xs text-red-700">
+          Some live metrics failed to load. Showing what's available.
+        </div>
+      )}
+
+      <WorkRollupPanel query={workRollup} />
+
+      {/* Live metrics */}
+      <h2 className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2">
+        Live {isLoading && <span className="text-gray-300 normal-case">· loading…</span>}
+      </h2>
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <MetricTile
+          label="Registry · Things"
+          current={registryThings}
+          baseline={BASELINE.registryThings}
+          format="count"
+          higherIsBetter
+          color="#6366f1"
+        />
+        <MetricTile
+          label="Canonical-ID coverage (any)"
+          current={canonicalAnyPct}
+          baseline={BASELINE.canonicalIdAnyPct}
+          format="pct"
+          higherIsBetter
+          color="#10b981"
+        />
+        <MetricTile
+          label="Extraction quality (avg)"
+          current={extractionAvg}
+          baseline={BASELINE.extractionQualityAvg}
+          format="score"
+          higherIsBetter
+          sparkline={qualityTrend}
+          color="#10b981"
+        />
+        <MetricTile
+          label="Low-quality tail (< 0.5)"
+          current={lowQualityPct}
+          baseline={BASELINE.extractionLowQualityPct}
+          format="pct"
+          higherIsBetter={false}
+          sparkline={lowQualityTrend}
+          color="#f59e0b"
+        />
+      </div>
+
+      {/* Pending backend */}
+      <h2 className="text-xs font-medium text-gray-400 uppercase tracking-wider mb-2">
+        Pending backend
+      </h2>
+      <div className="grid grid-cols-4 gap-4">
+        <StubTile
+          label="Edition fragmentation rate"
+          baseline={BASELINE.editionFragmentationBooksPct}
+          format="pct"
+          pendingIssue="#396"
+        />
+        <StubTile
+          label="% entities linked to a Work"
+          baseline={null}
+          format="pct"
+          pendingIssue="#396"
+        />
+        <StubTile
+          label="ER precision / recall / F1"
+          baseline={null}
+          format="score"
+          pendingIssue="#400"
+        />
+        <StubTile
+          label="Semantic recall@K"
+          baseline={null}
+          format="score"
+          pendingIssue="#400"
+        />
+        <StubTile
+          label="Series · avg size"
+          baseline={BASELINE.seriesAvgSize}
+          format="score"
+          pendingIssue="#396"
+        />
+      </div>
+    </>
+  );
+}

--- a/src/pages/scorecard/baseline.js
+++ b/src/pages/scorecard/baseline.js
@@ -1,0 +1,20 @@
+// Frozen pre-epic baseline for the ER/KG scorecard (epic #395, issue #403).
+// Captured 2026-06-07 — do NOT recompute these. They are the fixed reference
+// point every metric is measured against as the entity-resolution epic lands.
+export const BASELINE_DATE = '2026-06-07';
+
+// Raw figures from the issue, kept verbatim for traceability.
+export const BASELINE = {
+  registryThings: 80383,
+  registryBooks: 2165,
+  canonicalIdAnyPct: 97.3,
+  canonicalIdStrongPct: 95.4,
+  editionFragmentationClusters: 80,
+  editionFragmentationThings: 182,
+  editionFragmentationBooksPct: 8.4,
+  seriesCount: 10,
+  seriesBooks: 44,
+  seriesAvgSize: 4.4,
+  extractionQualityAvg: 0.487,
+  extractionLowQualityPct: 32.1,
+};


### PR DESCRIPTION
## ER/KG success scorecard (#403)

New `/scorecard` page under the **Registry** nav — the home for measuring the entity-resolution epic (#395) against the frozen **2026-06-07** baseline.

### What's in it
- **Live tiles** (baseline · current · delta · sparkline) wired to existing `/metrics/*` endpoints: registry size, canonical-ID coverage, extraction-quality avg, low-quality tail. Delta chips colour by direction (green = better, accounting for "lower is better" on the tail).
- **Work-rollup readiness panel** from `GET /metrics/work-rollup` (the "is it time to flip `WORK_LEVEL_CONSENSUS`?" signal): readiness verdict, message verbatim, curation/delta stats, flag state. Degrades to an "awaiting deploy" placeholder until the endpoint is live.
- **Stub tiles** for metrics pending backend work (#396 / #400), each badged with its child issue and the known baseline.
- New hooks (dedup effectiveness, quality trends, low-quality things, work-rollup) and a shared `Sparkline` component.

### Verification
- Lint + production build pass.
- Driven headless against mocked endpoint payloads (incl. the backend's sample work-rollup `emerging` response) — renders clean, no console errors.

### Follow-ups (filed separately)
- Confirm the canonical-ID coverage field on `/metrics/deduplication/effectiveness` (tile currently probes several key names defensively).
- Weekly snapshot persistence for true historical trends (the second done-criterion in #403).

Closes #403 once the two follow-ups land.
