### PR TITLE
feat(search): search-quality inspector — lexical vs hybrid (#406)

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -13,6 +13,7 @@ import PipelinePage from './pages/pipeline/PipelinePage';
 import SettingsPage from './pages/settings/SettingsPage';
 import ApisPage from './pages/apis/ApisPage';
 import EmailsPage from './pages/emails/EmailsPage';
+import SearchQualityPage from './pages/search-quality/SearchQualityPage';
 
 const queryClient = new QueryClient({
   defaultOptions: {
@@ -42,6 +43,7 @@ export default function App() {
               <Route path="worker" element={<WorkerPage />} />
               <Route path="moderation" element={<ModerationPage />} />
               <Route path="quality" element={<QualityPage />} />
+              <Route path="search-quality" element={<SearchQualityPage />} />
               <Route path="pipeline" element={<PipelinePage />} />
               <Route path="apis" element={<ApisPage />} />
               <Route path="emails" element={<EmailsPage />} />

--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -217,3 +217,14 @@ export function useSeedHistory(limit = 20) {
     staleTime: 15_000,
   });
 }
+
+// --- Search-quality inspector (#406) ---
+export function useHybridSearch(query, limit = 20) {
+  return useQuery({
+    queryKey: ['search', 'hybrid', query, limit],
+    queryFn: () => client.get('/search/hybrid', { params: { q: query, limit } }).then(r => r.data),
+    enabled: !!query,
+    retry: false,
+    staleTime: 60_000,
+  });
+}

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -28,6 +28,7 @@ const NAV_SECTIONS = [
     items: [
       { to: '/moderation', label: 'Moderation' },
       { to: '/quality', label: 'Quality Metrics' },
+      { to: '/search-quality', label: 'Search Quality' },
     ],
   },
   {

--- a/src/pages/search-quality/SearchQualityPage.jsx
+++ b/src/pages/search-quality/SearchQualityPage.jsx
@@ -1,0 +1,132 @@
+import { useState } from 'react';
+import PageHeader from '../../components/PageHeader';
+import { useHybridSearch } from '../../api/hooks';
+import { MOCK_HYBRID } from './mockSearch';
+
+const JUDGE_KEY = 'searchJudgments_v1';
+
+function loadJudgments() {
+  try { return JSON.parse(sessionStorage.getItem(JUDGE_KEY)) || {}; } catch { return {}; }
+}
+
+function titleOf(r) {
+  return r.display_name || r.title || r.name || r.metadata?.title || r.thing_id;
+}
+
+function ResultRow({ rank, r, relevance, onJudge }) {
+  const f = r._fusion || {};
+  const vectorOnly = f.lexical_rank == null && f.vector_rank != null;
+  return (
+    <div className="flex items-center gap-2 py-1.5 border-t border-gray-50 text-xs">
+      <span className="w-5 text-right text-gray-400 tabular-nums">{rank}</span>
+      <div className="flex-1 min-w-0">
+        <div className="font-medium text-gray-700 truncate">{titleOf(r)}</div>
+        <div className="text-gray-400 flex items-center gap-1.5">
+          <span>{r.type}</span>
+          {f.lexical_rank != null && <span className="px-1 rounded bg-gray-100">L{f.lexical_rank}</span>}
+          {f.vector_rank != null && <span className="px-1 rounded bg-gray-100">V{f.vector_rank}</span>}
+          {vectorOnly && <span className="px-1 rounded bg-violet-50 text-violet-600">semantic-only</span>}
+        </div>
+      </div>
+      <div className="flex gap-1 shrink-0">
+        <button onClick={() => onJudge(r.thing_id, relevance === true ? null : true)} className={`px-1.5 rounded ${relevance === true ? 'bg-green-600 text-white' : 'border border-gray-200 text-gray-400 hover:bg-gray-50'}`}>✓</button>
+        <button onClick={() => onJudge(r.thing_id, relevance === false ? null : false)} className={`px-1.5 rounded ${relevance === false ? 'bg-red-500 text-white' : 'border border-gray-200 text-gray-400 hover:bg-gray-50'}`}>✗</button>
+      </div>
+    </div>
+  );
+}
+
+export default function SearchQualityPage() {
+  const [input, setInput] = useState('');
+  const [query, setQuery] = useState('');
+  const live = useHybridSearch(query);
+
+  const data = live.data?.results ? live.data : (query ? MOCK_HYBRID : null);
+  const usingSample = !!query && !live.data?.results;
+  const results = data?.results || [];
+
+  const [judgments, setJudgments] = useState(loadJudgments);
+  const judged = judgments[query] || {};
+
+  function judge(thingId, relevant) {
+    const next = { ...judgments, [query]: { ...(judgments[query] || {}) } };
+    if (relevant == null) delete next[query][thingId];
+    else next[query][thingId] = relevant;
+    setJudgments(next);
+    try { sessionStorage.setItem(JUDGE_KEY, JSON.stringify(next)); } catch { /* quota */ }
+  }
+
+  function exportGolden() {
+    const set = Object.entries(judgments).map(([q, j]) => ({
+      query: q,
+      judgments: Object.entries(j).map(([thing_id, relevant]) => ({ thing_id, relevant })),
+    }));
+    const blob = new Blob([JSON.stringify(set, null, 2)], { type: 'application/json' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url; a.download = 'search-golden-queries.json'; a.click();
+    URL.revokeObjectURL(url);
+  }
+
+  const lexical = [...results].filter(r => r._fusion?.lexical_rank != null).sort((a, b) => a._fusion.lexical_rank - b._fusion.lexical_rank);
+  const semanticWins = results.filter(r => r._fusion?.lexical_rank == null && r._fusion?.vector_rank != null).length;
+  const judgedCount = Object.keys(judgments).reduce((s, q) => s + Object.keys(judgments[q]).length, 0);
+
+  return (
+    <>
+      <PageHeader
+        title="Search Quality Inspector"
+        description="Run a query, compare lexical vs hybrid (RRF) ranking, and mark relevance to build the semantic-recall golden query set (#406 → #400)."
+      />
+
+      <form
+        onSubmit={e => { e.preventDefault(); setQuery(input.trim()); }}
+        className="mb-4 flex items-center gap-2"
+      >
+        <input
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          placeholder="Search query… (e.g. dune)"
+          className="flex-1 px-3 py-2 border border-gray-200 rounded text-sm focus:outline-none focus:ring-2 focus:ring-indigo-500"
+        />
+        <button type="submit" className="px-3 py-2 rounded bg-indigo-600 text-white text-sm hover:bg-indigo-700">Search</button>
+        <button type="button" onClick={exportGolden} disabled={judgedCount === 0} className="px-3 py-2 rounded border border-gray-200 text-sm text-gray-600 hover:bg-gray-50 disabled:opacity-40">
+          Export golden set ({judgedCount})
+        </button>
+      </form>
+
+      {!query ? (
+        <div className="bg-white rounded-lg border border-gray-200 p-8 text-center text-sm text-gray-400">
+          Enter a query to compare lexical vs hybrid ranking and judge relevance.
+        </div>
+      ) : (
+        <>
+          <div className={`mb-4 p-3 rounded border text-xs ${usingSample ? 'border-amber-200 bg-amber-50 text-amber-800' : 'border-indigo-100 bg-indigo-50 text-indigo-800'}`}>
+            {usingSample
+              ? <>Seeded sample — live <code>/search/hybrid</code> needs an authed session.</>
+              : <>Live <code>/search/hybrid</code> · mode <span className="font-medium">{data.mode}</span> · {data.count} results.</>}
+            {' '}<span className="text-violet-600">{semanticWins} semantic-only win(s)</span> the lexical ranker missed.
+          </div>
+
+          <div className="grid grid-cols-2 gap-4">
+            <div className="bg-white rounded-lg border border-gray-200 p-4">
+              <h2 className="text-sm font-medium text-gray-700 mb-1">Lexical (FTS)</h2>
+              <p className="text-[11px] text-gray-400 mb-1">ranked by lexical_rank · vector-only results excluded</p>
+              {lexical.length ? lexical.map((r, i) => (
+                <ResultRow key={r.thing_id} rank={i + 1} r={r} relevance={judged[r.thing_id]} onJudge={judge} />
+              )) : <div className="text-xs text-gray-400 py-4">No lexical hits.</div>}
+            </div>
+
+            <div className="bg-white rounded-lg border border-indigo-100 p-4">
+              <h2 className="text-sm font-medium text-gray-700 mb-1">Hybrid (RRF)</h2>
+              <p className="text-[11px] text-gray-400 mb-1">fused lexical + vector · semantic-only highlighted</p>
+              {results.map((r, i) => (
+                <ResultRow key={r.thing_id} rank={i + 1} r={r} relevance={judged[r.thing_id]} onJudge={judge} />
+              ))}
+            </div>
+          </div>
+        </>
+      )}
+    </>
+  );
+}

--- a/src/pages/search-quality/mockSearch.js
+++ b/src/pages/search-quality/mockSearch.js
@@ -1,0 +1,17 @@
+// Seeded sample for the search-quality inspector (#406), shaped like
+// GET /search/hybrid. _fusion carries the per-result lexical_rank / vector_rank
+// that drives the lexical-vs-hybrid A/B. Replaced by live results when reachable.
+export const MOCK_HYBRID = {
+  mode: 'hybrid',
+  query: 'dune',
+  count: 7,
+  results: [
+    { thing_id: 't-d1', display_name: 'Dune', type: 'book', _fusion: { rrf: 0.0312, lexical_rank: 1, vector_rank: 2 } },
+    { thing_id: 't-d2', display_name: 'Dune Messiah', type: 'book', _fusion: { rrf: 0.0301, lexical_rank: 2, vector_rank: 4 } },
+    { thing_id: 't-d3', display_name: 'Dune (2021 film)', type: 'movie', _fusion: { rrf: 0.0288, lexical_rank: 3, vector_rank: 7 } },
+    { thing_id: 't-d4', display_name: 'Children of Dune', type: 'book', _fusion: { rrf: 0.0166, lexical_rank: null, vector_rank: 1 } }, // semantic-only win
+    { thing_id: 't-d5', display_name: 'Arrakis: The Dune Encyclopedia', type: 'book', _fusion: { rrf: 0.0161, lexical_rank: 9, vector_rank: 3 } },
+    { thing_id: 't-d6', display_name: 'God Emperor of Dune', type: 'book', _fusion: { rrf: 0.0159, lexical_rank: null, vector_rank: 5 } }, // semantic-only win
+    { thing_id: 't-d7', display_name: 'The Spice Must Flow', type: 'book', _fusion: { rrf: 0.0142, lexical_rank: 14, vector_rank: 9 } },
+  ],
+};


### PR DESCRIPTION
Lexical-vs-hybrid inspector against /search/hybrid + relevance judging → golden query set. See #406.

Closes #406