### PR TITLE
Admin 2026-07 backlog follow-ups: scorecard contract fixes + Places monitor

### DIFF
--- a/docs/admin-updates-plan-2026-07.md
+++ b/docs/admin-updates-plan-2026-07.md
@@ -15,7 +15,10 @@ Effort: XS < 1h · S ~½ day · M ~1–2 days · L > 2 days.
 
 ## P0 — Confirmed contract drift (no backend dependency)
 
-### A1 · Scorecard: read stable canonical-ID coverage field + add "strong" tile
+> **Status (2026-07-16):** A1 + A2 ✅ shipped (branch `feat/admin-2026-07-backlog`). B1+B2 ✅ built
+> (Places monitor), now live against #470.
+
+### A1 · Scorecard: read stable canonical-ID coverage field + add "strong" tile — ✅ DONE
 - **Source:** #414 (closed, backend `4446a33`).
 - **Why:** `ScorecardPage.jsx:234–238` still defensively probes 4 guessed key names. Backend now
   returns a documented shape:
@@ -29,7 +32,7 @@ Effort: XS < 1h · S ~½ day · M ~1–2 days · L > 2 days.
 - **Acceptance:** "any" tile reads 97.3 with no key-probing; "strong" tile renders 96.6 vs 95.4 baseline.
 - **Effort:** XS.
 
-### A2 · Scorecard: confirm fragmentation baseline + surface Work-structure metrics
+### A2 · Scorecard: confirm fragmentation baseline + surface Work-structure metrics — ✅ DONE
 - **Source:** #418 (closed, backend `35e7d4d`).
 - **Why:** already mostly wired — scorecard reads `fragmentation_pct` from snapshots (`:218`) and
   `editions_linked` (`:220`). #418 redefined the metric to *unresolved* clusters (live 2 / 0.2% vs
@@ -59,7 +62,7 @@ source). Nothing breaks, but the admin cannot observe the epic's central mechani
 > rows; `/admin/type-rules` exists and is consumed in `PipelinePage`), so B3 shrinks to an optional
 > drift panel.
 
-### B1+B2 · New "Places" monitor — `entity_kind` distribution + chain-location watch
+### B1+B2 · New "Places" monitor — `entity_kind` distribution + chain-location watch — ✅ BUILT
 - **Source:** #456 W3 (#459), #453 (entity_kind classifier); #456 W5 (#462) — decision was to **leave**
   ~8,557 Hotels + ~1,426 Restaurants in place and "re-open the prune question only if usage data shows
   chain-location Things are actively polluting rankings/discovery." That signal belongs in the admin.
@@ -67,10 +70,15 @@ source). Nothing breaks, but the admin cannot observe the epic's central mechani
   destination, by type) so the classifier's live output is observable, and (b) a **chain-location
   pollution** tile — count + sample of Restaurant/Hotel Things carrying a `google_place_id` + a
   recognized chain brand (the merge-into-brand candidates from #456's migration notes), ideally trended.
-- **Backend dependency:** one companion endpoint — `GET /metrics/places/entity-kind` (aggregate) +
-  chain-location candidate count/sample. **Filed as tnats/listgem-platform#470** (backend · admin-portal
-  · place-identification). Admin render work starts once the shape lands; seeded-sample fallback until then.
-- **Effort:** M (admin) + backend.
+- **Backend dependency:** ✅ `GET /metrics/places/entity-kind` shipped (tnats/listgem-platform#470/#471).
+  Key result: `entity_kind` is **derived** (not persisted — seeded Wikidata catalog never ran the
+  classifier, defaults to `destination`), and `chain_location_candidates.total = 0` on prod — **zero**
+  seeded Places carry a `google_place_id`, so there is no chain-location pollution and the #462 prune
+  stays deferred with data. Contract documented in `CLAUDE-SHARED.md` "Place entity_kind monitor".
+- **Built:** `/places` page (`src/pages/places/`), hook `usePlacesEntityKind`, nav under Registry.
+  Renders entity_kind distribution bar + by-type cross-tab + chain-location panel; derived-caveat
+  callout; seeded-sample fallback. Lint + build + SSR smoke-render verified.
+- **Effort:** M (admin) + backend — both done.
 
 ### B3 · Taxonomy-drift panel (optional)
 - **Source:** #441 (VisualArtwork/Painting contradiction + 24 drifted `parent_type` rows); #456 taxonomy prune.

--- a/docs/admin-updates-plan-2026-07.md
+++ b/docs/admin-updates-plan-2026-07.md
@@ -96,12 +96,16 @@ source). Nothing breaks, but the admin cannot observe the epic's central mechani
 
 ## P2 — Quality surfaces the new fixes make observable
 
-### C1 · Triage: mistyped-Person / non-content-type issue category
+### C1 · Triage: mistyped-Person / non-content-type issue category — ✅ DONE
 - **Source:** #442 (article byline extracted as Person Thing), #429 (Person floods type-implied search).
-- **Change:** add a "mistyped Person" category to the triage `issue_breakdown` so re-enrich can target them.
-- **Backend dependency:** classify/emit the category on `/metrics/low-quality-things` — **filed
-  tnats/listgem-platform#472** (backend · admin-portal · epic:entity-resolution). Admin render follows.
-- **Effort:** S (+ backend).
+- **Backend:** ✅ live — `#472` shipped; `/metrics/low-quality-things` `issue_breakdown` includes
+  `person_as_content`, and `?issue=person_as_content` returns the rows (contracts handed off in #476).
+- **Built:** a `person-as-content` chip on Triage. Because it's **quality-independent** (wrong-type, not
+  low-score), selecting it fetches server-side via `?issue=person_as_content` (not the quality<0.5 tail);
+  the chip's heuristic shows on hover; a context note explains "~0 today, lights up on regressions".
+  Reuses the existing per-item re-enrich. Seeded-sample rows + breakdown added for offline demo.
+- **Verified:** eslint, build, SSR smoke.
+- **Effort:** S — done.
 
 ### C2 · Search inspector: type-facet distribution view — ✅ DONE
 - **Source:** #429 — the relevance regression is only visible as a type distribution (Person 65% of "Best TV Series").
@@ -115,22 +119,24 @@ source). Nothing breaks, but the admin cannot observe the epic's central mechani
 
 ## P3 — New backend capabilities worth an admin control surface
 
-### D1 · Triage: quality-tail re-enrich sweep controls
-- **Source:** #420 — flag-gated background re-enrich sweep (kill switch, batches, worst-first).
-- **Change:** surface sweep status + batch progress + a trigger on the triage page (beyond the current per-item re-enrich).
-- **Backend dependency:** a sweep status/trigger endpoint — **filed tnats/listgem-platform#473**
-  (backend · admin-portal · epic:entity-resolution). Caveat filed: confirm #420's sweep actually shipped
-  vs. specced; admin panel holds behind "awaiting deploy" if not.
-- **Effort:** M (+ backend).
+### D1 · Triage: quality-tail re-enrich sweep panel — ✅ DONE (read-only)
+- **Source:** #420 — worst-first background re-enrich sweep.
+- **Backend:** ✅ live — `#473` shipped `GET /admin/re-enrich/sweep/status`. Hand-off clarified the sweep
+  is a **manual CLI, not a daemon** (`running: null`, `flag_name: null`) → **read-only panel, no kill
+  switch / start button** (correcting the original "controls" framing).
+- **Built:** a read-only sweep panel on Triage — progress (processed / pool), `avg_quality_delta`,
+  `last_run_at`, outcomes, "manual CLI" badge; `available:false` → "awaiting deploy". Seeded sample for demo.
+- **Verified:** eslint, build, SSR smoke (live + awaiting states).
+- **Effort:** M — done.
 
-### D2 · Image-quality page: dead-link + Commons-normalization metrics
-- **Source:** #424 — dead-link detection, Commons thumbnail normalization, `image_quality_score` decision.
-- **Change:** add broken/dead-image and normalized-coverage metrics to `ImageQualityPage`.
-- **Backend dependency:** the corresponding fields on the image analytics endpoints — **filed
-  tnats/listgem-platform#474** (backend · admin-portal). Caveat filed: #424's dead-link detection (item 4)
-  was "never implemented" — may need building, not just exposing; suggested split (ship
-  `commons_normalized_pct` now, track broken-image against the sweep work).
-- **Effort:** S–M (+ backend).
+### D2 · Image-quality page: dead-link + Commons-normalization metrics — ✅ DONE
+- **Source:** #424 — dead-link detection, Commons thumbnail normalization.
+- **Backend:** ✅ live — `#474` extended `/admin/analytics/image-quality` with `broken_image` (+ per-type
+  `broken`), `last_dead_link_scan_at`, `commons_total`, `commons_normalized_pct` (contracts in #476).
+- **Built:** a "Broken Images" stat card (starts at 0, fills as the daily sweep runs), a Commons
+  normalization bar (100% "done" today), and a per-type Broken column on the coverage table.
+- **Verified:** eslint, build, SSR smoke (seeded payload).
+- **Effort:** S–M — done.
 
 ---
 

--- a/docs/admin-updates-plan-2026-07.md
+++ b/docs/admin-updates-plan-2026-07.md
@@ -95,7 +95,8 @@ source). Nothing breaks, but the admin cannot observe the epic's central mechani
 ### C1 · Triage: mistyped-Person / non-content-type issue category
 - **Source:** #442 (article byline extracted as Person Thing), #429 (Person floods type-implied search).
 - **Change:** add a "mistyped Person" category to the triage `issue_breakdown` so re-enrich can target them.
-- **Backend dependency:** classify/emit the category on `/metrics/low-quality-things`.
+- **Backend dependency:** classify/emit the category on `/metrics/low-quality-things` — **filed
+  tnats/listgem-platform#472** (backend · admin-portal · epic:entity-resolution). Admin render follows.
 - **Effort:** S (+ backend).
 
 ### C2 · Search inspector: type-facet distribution view — ✅ DONE
@@ -113,13 +114,18 @@ source). Nothing breaks, but the admin cannot observe the epic's central mechani
 ### D1 · Triage: quality-tail re-enrich sweep controls
 - **Source:** #420 — flag-gated background re-enrich sweep (kill switch, batches, worst-first).
 - **Change:** surface sweep status + batch progress + a trigger on the triage page (beyond the current per-item re-enrich).
-- **Backend dependency:** a sweep status/trigger endpoint.
+- **Backend dependency:** a sweep status/trigger endpoint — **filed tnats/listgem-platform#473**
+  (backend · admin-portal · epic:entity-resolution). Caveat filed: confirm #420's sweep actually shipped
+  vs. specced; admin panel holds behind "awaiting deploy" if not.
 - **Effort:** M (+ backend).
 
 ### D2 · Image-quality page: dead-link + Commons-normalization metrics
 - **Source:** #424 — dead-link detection, Commons thumbnail normalization, `image_quality_score` decision.
 - **Change:** add broken/dead-image and normalized-coverage metrics to `ImageQualityPage`.
-- **Backend dependency:** the corresponding fields on the image analytics endpoints.
+- **Backend dependency:** the corresponding fields on the image analytics endpoints — **filed
+  tnats/listgem-platform#474** (backend · admin-portal). Caveat filed: #424's dead-link detection (item 4)
+  was "never implemented" — may need building, not just exposing; suggested split (ship
+  `commons_normalized_pct` now, track broken-image against the sweep work).
 - **Effort:** S–M (+ backend).
 
 ---

--- a/docs/admin-updates-plan-2026-07.md
+++ b/docs/admin-updates-plan-2026-07.md
@@ -80,13 +80,17 @@ source). Nothing breaks, but the admin cannot observe the epic's central mechani
   callout; seeded-sample fallback. Lint + build + SSR smoke-render verified.
 - **Effort:** M (admin) + backend — both done.
 
-### B3 · Taxonomy-drift panel (optional)
+### B3 · Taxonomy Health panel (optional) — ✅ BUILT (partial)
 - **Source:** #441 (VisualArtwork/Painting contradiction + 24 drifted `parent_type` rows); #456 taxonomy prune.
-- **Note:** the original "route type enums through `/admin/type-rules`" ask is largely already satisfied
-  — filters are data-driven and the endpoint exists. Remaining value is a small **taxonomy-drift panel**
-  (drifted `parent_type` count, retired-type sightings) on the Pipeline or a settings page.
-- **Backend dependency:** a drift count on `/admin/type-rules` (or a small `/metrics/taxonomy-drift`).
-- **Effort:** S. **Downgraded to P2** — nice-to-have, not epic-critical.
+- **Built:** a **Taxonomy Health** panel on the Pipeline page. The **retired-type sightings** half is fully
+  live with no backend dependency — computed client-side from `/metrics/quality-by-type` per-type counts,
+  flagging any of the #456-retired commodity types (Cafe/Gym/Bar/Store) that still carry Things
+  (`curation-clean` when all zero). Verified: eslint, build, SSR smoke (awaiting/clean/polluted states).
+- **Still pending backend:** the **parent-type drift** count (#441's 24 rows) needs a server-side field —
+  the panel reads `quality_by_type.parent_type_drift` / `drift_count` defensively and shows "awaiting
+  backend drift count" until then. **Not yet filed** — a small `/metrics/quality-by-type` field or
+  `/metrics/taxonomy-drift` ask; file if the drift number is wanted live.
+- **Effort:** S — done (retired-type half); drift half awaits a backend field.
 
 ---
 

--- a/docs/admin-updates-plan-2026-07.md
+++ b/docs/admin-updates-plan-2026-07.md
@@ -98,11 +98,13 @@ source). Nothing breaks, but the admin cannot observe the epic's central mechani
 - **Backend dependency:** classify/emit the category on `/metrics/low-quality-things`.
 - **Effort:** S (+ backend).
 
-### C2 · Search inspector: type-facet distribution view
+### C2 · Search inspector: type-facet distribution view — ✅ DONE
 - **Source:** #429 — the relevance regression is only visible as a type distribution (Person 65% of "Best TV Series").
-- **Change:** add a facet/type-distribution panel to `SearchQualityPage` (via `?facets=true` /
-  `/search/hybrid` facets) alongside the existing relevance judging, so Person-flooding regressions are visible.
-- **Effort:** S.
+- **Built:** a `TypeDistribution` panel on `SearchQualityPage` — computed **client-side** from the ranked
+  results (no backend facets needed), with a "Person-dominated · likely #429" flag when Person is the top
+  type. Added a query-aware seeded sample (`mockFor` / `MOCK_TV_SERIES`) so the flood case demos offline.
+- **Verified:** eslint, build, SSR smoke (mockFor selection + facet math + panel render).
+- **Effort:** S — done.
 
 ---
 

--- a/docs/admin-updates-plan-2026-07.md
+++ b/docs/admin-updates-plan-2026-07.md
@@ -1,0 +1,126 @@
+# Admin app updates — 2026-07 backlog review
+
+Plan derived from the batch of platform issues closed **2026-06 → 2026-07-16** (`tnats/listgem-platform`).
+Each item below is written as a fileable issue. Admin + backend issues both live in `tnats/listgem-platform`.
+
+**Architecture note:** every admin page already uses a *live-endpoint-with-mock-fallback* pattern — it
+renders live data when authed and a "seeded sample" otherwise. So the mock files are not defects; the
+work here is **contract drift** (fields backend changed) and **strategic gaps** (mechanisms the new
+backend work introduced that the admin can't yet observe).
+
+Priority key: **P0** confirmed drift, ship now · **P1** #456 epic alignment · **P2** quality surfaces · **P3** enhancements.
+Effort: XS < 1h · S ~½ day · M ~1–2 days · L > 2 days.
+
+---
+
+## P0 — Confirmed contract drift (no backend dependency)
+
+### A1 · Scorecard: read stable canonical-ID coverage field + add "strong" tile
+- **Source:** #414 (closed, backend `4446a33`).
+- **Why:** `ScorecardPage.jsx:234–238` still defensively probes 4 guessed key names. Backend now
+  returns a documented shape:
+  ```jsonc
+  "canonical_id_coverage": { "any_pct": 97.3, "strong_pct": 96.6, "any_count": 78176, "strong_count": 77646, "total": 80385 }
+  ```
+- **Change:**
+  - Replace probing with `dedupData.canonical_id_coverage.any_pct` (keep `canonical_id_coverage_pct` alias as one-line fallback).
+  - Add a **"Canonical-ID coverage (strong)"** `MetricTile` using `.strong_pct`; baseline already present as `BASELINE.canonicalIdStrongPct` (95.4). Live is 96.6.
+- **Files:** `src/pages/scorecard/ScorecardPage.jsx`, `src/pages/scorecard/baseline.js`.
+- **Acceptance:** "any" tile reads 97.3 with no key-probing; "strong" tile renders 96.6 vs 95.4 baseline.
+- **Effort:** XS.
+
+### A2 · Scorecard: confirm fragmentation baseline + surface Work-structure metrics
+- **Source:** #418 (closed, backend `35e7d4d`).
+- **Why:** already mostly wired — scorecard reads `fragmentation_pct` from snapshots (`:218`) and
+  `editions_linked` (`:220`). #418 redefined the metric to *unresolved* clusters (live 2 / 0.2% vs
+  baseline 80 / 8.4%) and added `works_total` (82), `works_multi_edition` (82) to the snapshot JSONB.
+- **Change:** confirm `baseline.js` fragmentation baseline = 8.4% and the tile note states the
+  definition change vs the 2026-06-07 baseline. Optionally add `MiniStat`s for `works_total` /
+  `works_multi_edition`.
+- **Files:** `src/pages/scorecard/ScorecardPage.jsx`, `src/pages/scorecard/baseline.js`.
+- **Acceptance:** fragmentation tile shows ~0.2% trending against an 8.4% baseline; structure metrics visible.
+- **Effort:** XS.
+
+---
+
+## P1 — Align with the #456 "curation, not directory" epic
+
+The epic (W1–W5, all closed 2026-07-16) is a positioning pivot: **brands/destinations are modeled,
+franchise/commodity-local is not.** `entity_kind` (chain/brand/destination) is now a first-class
+ingestion classifier and Cafe/Gym/Bar/Store are retired from the taxonomy. The admin app has **zero
+representation** of any of this today (grep of `src/` finds no `entity_kind`, chain/brand, or local
+source). Nothing breaks, but the admin cannot observe the epic's central mechanism.
+
+> **Refinement (2026-07-16 code audit):** `entity_kind` (chain/brand/destination) is a
+> **Place/Organization** signal, but the entity browser is **Work/edition-centric** (creative works —
+> books/movies), so it is the wrong home for it. The admin has *no* place-centric surface today. B1 and
+> B2 therefore merge into **one new "Places" monitor** (B1+B2 below), backed by a single new backend
+> endpoint. Separately, type filters are already **data-driven** (triage's dropdown derives from returned
+> rows; `/admin/type-rules` exists and is consumed in `PipelinePage`), so B3 shrinks to an optional
+> drift panel.
+
+### B1+B2 · New "Places" monitor — `entity_kind` distribution + chain-location watch
+- **Source:** #456 W3 (#459), #453 (entity_kind classifier); #456 W5 (#462) — decision was to **leave**
+  ~8,557 Hotels + ~1,426 Restaurants in place and "re-open the prune question only if usage data shows
+  chain-location Things are actively polluting rankings/discovery." That signal belongs in the admin.
+- **Change:** a new `/places` admin page with (a) an `entity_kind` distribution (chain vs brand vs
+  destination, by type) so the classifier's live output is observable, and (b) a **chain-location
+  pollution** tile — count + sample of Restaurant/Hotel Things carrying a `google_place_id` + a
+  recognized chain brand (the merge-into-brand candidates from #456's migration notes), ideally trended.
+- **Backend dependency:** one companion endpoint — `GET /metrics/places/entity-kind` (aggregate) +
+  chain-location candidate count/sample. **Filed as tnats/listgem-platform#470** (backend · admin-portal
+  · place-identification). Admin render work starts once the shape lands; seeded-sample fallback until then.
+- **Effort:** M (admin) + backend.
+
+### B3 · Taxonomy-drift panel (optional)
+- **Source:** #441 (VisualArtwork/Painting contradiction + 24 drifted `parent_type` rows); #456 taxonomy prune.
+- **Note:** the original "route type enums through `/admin/type-rules`" ask is largely already satisfied
+  — filters are data-driven and the endpoint exists. Remaining value is a small **taxonomy-drift panel**
+  (drifted `parent_type` count, retired-type sightings) on the Pipeline or a settings page.
+- **Backend dependency:** a drift count on `/admin/type-rules` (or a small `/metrics/taxonomy-drift`).
+- **Effort:** S. **Downgraded to P2** — nice-to-have, not epic-critical.
+
+---
+
+## P2 — Quality surfaces the new fixes make observable
+
+### C1 · Triage: mistyped-Person / non-content-type issue category
+- **Source:** #442 (article byline extracted as Person Thing), #429 (Person floods type-implied search).
+- **Change:** add a "mistyped Person" category to the triage `issue_breakdown` so re-enrich can target them.
+- **Backend dependency:** classify/emit the category on `/metrics/low-quality-things`.
+- **Effort:** S (+ backend).
+
+### C2 · Search inspector: type-facet distribution view
+- **Source:** #429 — the relevance regression is only visible as a type distribution (Person 65% of "Best TV Series").
+- **Change:** add a facet/type-distribution panel to `SearchQualityPage` (via `?facets=true` /
+  `/search/hybrid` facets) alongside the existing relevance judging, so Person-flooding regressions are visible.
+- **Effort:** S.
+
+---
+
+## P3 — New backend capabilities worth an admin control surface
+
+### D1 · Triage: quality-tail re-enrich sweep controls
+- **Source:** #420 — flag-gated background re-enrich sweep (kill switch, batches, worst-first).
+- **Change:** surface sweep status + batch progress + a trigger on the triage page (beyond the current per-item re-enrich).
+- **Backend dependency:** a sweep status/trigger endpoint.
+- **Effort:** M (+ backend).
+
+### D2 · Image-quality page: dead-link + Commons-normalization metrics
+- **Source:** #424 — dead-link detection, Commons thumbnail normalization, `image_quality_score` decision.
+- **Change:** add broken/dead-image and normalized-coverage metrics to `ImageQualityPage`.
+- **Backend dependency:** the corresponding fields on the image analytics endpoints.
+- **Effort:** S–M (+ backend).
+
+---
+
+## Suggested sequencing
+1. **A1, A2** now — XS, no dependencies, ship as one small PR.
+2. File backend companion issues for **B1, B2, C1, D1, D2** (fields/endpoints), then implement admin side as they land.
+3. **B3, C2** — admin-only, schedule after P0.
+
+## Not requiring admin changes (recorded for completeness)
+- **#432** type-aware image placeholder, **#430** create-and-add, **#463** retire location-clarification UI — all
+  `listgem-website` (main frontend), not admin.
+- **#460/#461/#462** W1/W2/W5 — product/backend; admin impact captured in B1/B2 above.
+- **#451** `/search-to-add/add` source enum — main-frontend add flow; admin does not call this endpoint.

--- a/src/App.jsx
+++ b/src/App.jsx
@@ -19,6 +19,7 @@ import ScorecardPage from './pages/scorecard/ScorecardPage';
 import LabelingPage from './pages/labeling/LabelingPage';
 import EntityBrowserPage from './pages/entities/EntityBrowserPage';
 import ErQueuePage from './pages/entities/ErQueuePage';
+import PlacesPage from './pages/places/PlacesPage';
 import TriagePage from './pages/triage/TriagePage';
 import SearchQualityPage from './pages/search-quality/SearchQualityPage';
 
@@ -56,6 +57,7 @@ export default function App() {
               <Route path="labeling" element={<LabelingPage />} />
               <Route path="entities" element={<EntityBrowserPage />} />
               <Route path="er-queue" element={<ErQueuePage />} />
+              <Route path="places" element={<PlacesPage />} />
               <Route path="triage" element={<TriagePage />} />
               <Route path="search-quality" element={<SearchQualityPage />} />
               <Route path="pipeline" element={<PipelinePage />} />

--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -216,6 +216,15 @@ export function useScorecardHistory() {
   });
 }
 
+// --- Places monitor (entity_kind distribution + chain-location signal, #470) ---
+export function usePlacesEntityKind() {
+  return useQuery({
+    queryKey: ['metrics', 'places-entity-kind'],
+    queryFn: () => client.get('/metrics/places/entity-kind').then(r => r.data),
+    staleTime: 60_000,
+  });
+}
+
 // --- Type Rules ---
 export function useTypeRules() {
   return useQuery({

--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -338,10 +338,11 @@ export function useErQueueMutations() {
 }
 
 // --- Extraction triage (#407) ---
-export function useLowQualityThings({ limit = 200, minQuality = 0.5 } = {}) {
+export function useLowQualityThings({ limit = 200, minQuality = 0.5, issue, enabled = true } = {}) {
   return useQuery({
-    queryKey: ['metrics', 'low-quality-things', limit, minQuality],
-    queryFn: () => client.get('/metrics/low-quality-things', { params: { limit, minQuality } }).then(r => r.data),
+    queryKey: ['metrics', 'low-quality-things', limit, minQuality, issue || null],
+    queryFn: () => client.get('/metrics/low-quality-things', { params: { limit, minQuality, issue } }).then(r => r.data),
+    enabled,
     staleTime: 60_000,
     retry: false, // fall back to the seeded sample when unreachable
   });
@@ -352,6 +353,16 @@ export function useReEnrich() {
   return useMutation({
     mutationFn: (thingId) => client.post(`/admin/re-enrich/${thingId}`).then(r => r.data),
     onSuccess: () => qc.invalidateQueries({ queryKey: ['metrics', 'low-quality-things'] }),
+  });
+}
+
+// Read-only quality-tail re-enrich sweep status (#473) — manual CLI, no controls.
+export function useReEnrichSweepStatus() {
+  return useQuery({
+    queryKey: ['admin', 're-enrich-sweep-status'],
+    queryFn: () => client.get('/admin/re-enrich/sweep/status').then(r => r.data),
+    staleTime: 30_000,
+    retry: false,
   });
 }
 

--- a/src/components/Sidebar.jsx
+++ b/src/components/Sidebar.jsx
@@ -17,6 +17,7 @@ const NAV_SECTIONS = [
       { to: '/labeling', label: 'Golden-Set Labeling' },
       { to: '/entities', label: 'Entity Browser' },
       { to: '/er-queue', label: 'ER Review Queue' },
+      { to: '/places', label: 'Places Monitor' },
     ],
   },
   {

--- a/src/pages/image-quality/ImageQualityPage.jsx
+++ b/src/pages/image-quality/ImageQualityPage.jsx
@@ -18,6 +18,12 @@ function coverageBg(value) {
   return 'bg-red-500';
 }
 
+function fmtDate(v) {
+  if (!v) return '—';
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleDateString();
+}
+
 export default function ImageQualityPage() {
   const { data, isLoading, error } = useImageQuality();
 
@@ -35,15 +41,24 @@ export default function ImageQualityPage() {
 
   const coveragePct = parseFloat(imageCoverage) || 0;
 
+  // Image rot + Commons normalization (#424 / #474). broken_image starts at 0
+  // and fills in as the daily dead-link sweep runs; commons_normalized_pct is a
+  // "done" bar (100% today).
+  const brokenImage = data?.broken_image ?? 0;
+  const lastDeadScan = data?.last_dead_link_scan_at;
+  const commonsTotal = data?.commons_total;
+  const commonsPct = data?.commons_normalized_pct;
+  const hasCommons = commonsPct != null;
+
   return (
     <>
       <PageHeader
         title="Image Quality"
-        description="Image coverage across the registry — missing images, ranked gaps, and per-type breakdown"
+        description="Image coverage across the registry — missing images, ranked gaps, broken-image rot, and Commons normalization"
       />
 
       {/* Summary Cards */}
-      <div className="grid grid-cols-3 gap-4 mb-6">
+      <div className="grid grid-cols-4 gap-4 mb-6">
         <StatCard
           label="Image Coverage"
           value={imageCoverage !== '—' ? imageCoverage : '—'}
@@ -59,7 +74,36 @@ export default function ImageQualityPage() {
           value={rankedMissing.toLocaleString()}
           detail="Visible on consensus pages"
         />
+        <StatCard
+          label="Broken Images"
+          value={brokenImage.toLocaleString()}
+          detail={lastDeadScan ? `dead links · scanned ${fmtDate(lastDeadScan)}` : 'dead links · fills in as the sweep runs'}
+        />
       </div>
+
+      {/* Commons normalization (#424) */}
+      {hasCommons && (
+        <div className="bg-white rounded-lg border border-gray-200 p-4 mb-6">
+          <div className="flex items-center justify-between mb-3">
+            <h2 className="text-sm font-medium text-gray-700">
+              Commons thumbnail normalization
+              {commonsTotal != null && <span className="text-gray-400 font-normal"> · {Number(commonsTotal).toLocaleString()} URLs</span>}
+            </h2>
+            {parseFloat(commonsPct) >= 100 && (
+              <span className="text-xs font-medium text-green-700 bg-green-50 px-1.5 py-0.5 rounded">done</span>
+            )}
+          </div>
+          <div className="flex items-center gap-3">
+            <div className="flex-1 h-4 bg-gray-100 rounded overflow-hidden">
+              <div className={`h-full rounded ${coverageBg(commonsPct)}`} style={{ width: `${Math.min(parseFloat(commonsPct) || 0, 100)}%` }} />
+            </div>
+            <span className={`text-sm font-medium tabular-nums ${coverageColor(commonsPct)}`}>
+              {typeof commonsPct === 'number' ? `${commonsPct.toFixed(1)}%` : commonsPct}
+            </span>
+          </div>
+          <p className="mt-2 text-xs text-gray-400">Wikimedia Commons originals rewritten to <code>https</code> + a width param (CDN thumbnail) — page-weight win on card tiles.</p>
+        </div>
+      )}
 
       {/* Coverage bar */}
       <div className="bg-white rounded-lg border border-gray-200 p-4 mb-6">
@@ -94,6 +138,7 @@ export default function ImageQualityPage() {
                   <th className="text-left pb-2">Type</th>
                   <th className="text-right pb-2">Total</th>
                   <th className="text-right pb-2">Missing</th>
+                  <th className="text-right pb-2">Broken</th>
                   <th className="text-right pb-2">Coverage</th>
                   <th className="pb-2 pl-4 w-32"></th>
                 </tr>
@@ -108,6 +153,11 @@ export default function ImageQualityPage() {
                       <td className="py-1.5 text-right tabular-nums">
                         <span className={t.missing > 0 ? 'text-red-500' : 'text-gray-400'}>
                           {t.missing}
+                        </span>
+                      </td>
+                      <td className="py-1.5 text-right tabular-nums">
+                        <span className={t.broken > 0 ? 'text-amber-600' : 'text-gray-300'}>
+                          {t.broken ?? 0}
                         </span>
                       </td>
                       <td className="py-1.5 text-right tabular-nums">

--- a/src/pages/pipeline/PipelinePage.jsx
+++ b/src/pages/pipeline/PipelinePage.jsx
@@ -2,14 +2,26 @@ import { useState } from 'react';
 import PageHeader from '../../components/PageHeader';
 import StatCard from '../../components/StatCard';
 import StatusBadge from '../../components/StatusBadge';
-import { useCrawlAnalytics, useRegistrySearch, useTypeRules, useQueueStats } from '../../api/hooks';
+import { useCrawlAnalytics, useRegistrySearch, useTypeRules, useQueueStats, useQualityByType } from '../../api/hooks';
 import client from '../../api/client';
+
+// Commodity types retired by #456 ("curation, not directory") — should be empty.
+const RETIRED_TYPES = ['Cafe', 'Gym', 'Bar', 'Store'];
 
 export default function PipelinePage() {
   const { data: crawls } = useCrawlAnalytics();
   const { data: registry } = useRegistrySearch();
   const { data: typeRulesData } = useTypeRules();
   const { data: queue } = useQueueStats();
+  const { data: byType } = useQualityByType();
+
+  // Taxonomy health: retired-type sightings from live per-type counts (#456).
+  const typeCounts = new Map((byType?.types || []).map(t => [String(t.type).toLowerCase(), parseInt(t.count) || 0]));
+  const hasTypeData = (byType?.types || []).length > 0;
+  const retiredSightings = RETIRED_TYPES.map(t => ({ type: t, count: typeCounts.get(t.toLowerCase()) ?? 0 }));
+  const sightingCount = retiredSightings.filter(r => r.count > 0).length;
+  // Parent-type drift (#441) — awaits a backend drift count; read defensively if present.
+  const parentTypeDrift = byType?.parent_type_drift ?? byType?.drift_count ?? null;
 
   // Re-crawl form
   const [recrawlUrl, setRecrawlUrl] = useState('');
@@ -189,6 +201,45 @@ export default function PipelinePage() {
               ))}
             </tbody>
           </table>
+        </div>
+      </div>
+
+      {/* Taxonomy Health — #456 retired-type prune + #441 parent-type drift */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4 mb-6">
+        <div className="flex items-center justify-between mb-1">
+          <h2 className="text-sm font-medium text-gray-700">Taxonomy Health</h2>
+          {hasTypeData && (
+            sightingCount === 0
+              ? <span className="text-xs font-medium text-green-700 bg-green-50 px-1.5 py-0.5 rounded">curation-clean</span>
+              : <span className="text-xs font-medium text-amber-700 bg-amber-50 px-1.5 py-0.5 rounded">{sightingCount} retired-type sighting{sightingCount === 1 ? '' : 's'}</span>
+          )}
+        </div>
+        <p className="text-xs text-gray-400 mb-3">
+          Commodity types retired by #456 (“curation, not directory”) should be empty.
+        </p>
+        {!hasTypeData ? (
+          <div className="text-xs text-gray-400">Awaiting live <code>/metrics/quality-by-type</code>.</div>
+        ) : (
+          <div className="grid grid-cols-4 gap-2">
+            {retiredSightings.map(r => (
+              <div key={r.type} className={`rounded border p-2 ${r.count > 0 ? 'border-amber-200 bg-amber-50' : 'border-gray-100 bg-gray-50'}`}>
+                <div className={`text-lg font-semibold tabular-nums ${r.count > 0 ? 'text-amber-700' : 'text-gray-300'}`}>{r.count}</div>
+                <div className="text-xs text-gray-500">{r.type}</div>
+              </div>
+            ))}
+          </div>
+        )}
+        {sightingCount > 0 && (
+          <p className="mt-2 text-[11px] text-amber-700">
+            {retiredSightings.filter(r => r.count > 0).map(r => r.type).join(', ')} still carry Things —
+            route their detection rules to Restaurant-as-brand or reject the URL (per #456).
+          </p>
+        )}
+        <div className="mt-3 pt-3 border-t border-gray-100 flex items-center justify-between text-xs">
+          <span className="text-gray-500">Parent-type drift <span className="text-gray-400">· #441</span></span>
+          {parentTypeDrift == null
+            ? <span className="text-gray-400">awaiting backend drift count</span>
+            : <span className={`tabular-nums font-medium ${parentTypeDrift > 0 ? 'text-amber-700' : 'text-green-700'}`}>{parentTypeDrift} drifted</span>}
         </div>
       </div>
 

--- a/src/pages/places/PlacesPage.jsx
+++ b/src/pages/places/PlacesPage.jsx
@@ -1,0 +1,199 @@
+import PageHeader from '../../components/PageHeader';
+import StatCard from '../../components/StatCard';
+import { usePlacesEntityKind } from '../../api/hooks';
+import { MOCK_PLACES } from './mockPlaces';
+
+const KIND_META = {
+  destination: { label: 'Destination', bar: 'bg-emerald-500', chip: 'bg-emerald-50 text-emerald-700' },
+  brand: { label: 'Brand', bar: 'bg-indigo-500', chip: 'bg-indigo-50 text-indigo-700' },
+  chain: { label: 'Chain', bar: 'bg-amber-500', chip: 'bg-amber-50 text-amber-700' },
+  unclassified: { label: 'Unclassified', bar: 'bg-gray-300', chip: 'bg-gray-100 text-gray-500' },
+};
+const kindMeta = k => KIND_META[k] || KIND_META.unclassified;
+const KIND_ORDER = ['destination', 'brand', 'chain'];
+
+const fmtInt = n => (n == null ? '—' : Number(n).toLocaleString());
+const rawPct = (n, total) => (total > 0 ? (n / total) * 100 : 0);
+function fmtPct(n, total) {
+  const p = rawPct(n, total);
+  if (p === 0) return '0%';
+  if (p < 0.1) return `${p.toFixed(2)}%`;
+  if (p < 10) return `${p.toFixed(1)}%`;
+  return `${p.toFixed(0)}%`;
+}
+
+export default function PlacesPage() {
+  const query = usePlacesEntityKind();
+  const live = query.data && Array.isArray(query.data.by_entity_kind) ? query.data : null;
+  const usingSample = !live;
+  const data = live || MOCK_PLACES;
+
+  const byKind = [...(data.by_entity_kind || [])].sort((a, b) => (b.count || 0) - (a.count || 0));
+  const total = data.places_total ?? byKind.reduce((s, r) => s + (r.count || 0), 0);
+  const kindCount = k => byKind.find(r => r.entity_kind === k)?.count ?? 0;
+
+  const byTypeKind = data.by_type_kind || [];
+  const types = [...new Set(byTypeKind.map(r => r.type))];
+  const typeRows = types
+    .map(type => {
+      const rows = byTypeKind.filter(r => r.type === type);
+      return {
+        type,
+        totalForType: rows.reduce((s, r) => s + (r.count || 0), 0),
+        kinds: Object.fromEntries(rows.map(r => [r.entity_kind, r.count])),
+      };
+    })
+    .sort((a, b) => b.totalForType - a.totalForType);
+
+  const candidates = data.chain_location_candidates || { total: 0, by_type: [], sample: [] };
+  const candidateTotal = candidates.total || 0;
+
+  return (
+    <>
+      <PageHeader
+        title="Places Monitor"
+        description="Place-Thing entity_kind distribution (chain · brand · destination) and the #462 chain-location pollution signal — the observability behind “curation, not directory” (#456)."
+      />
+
+      <div className={`mb-4 p-3 rounded border text-xs ${usingSample ? 'border-amber-200 bg-amber-50 text-amber-800' : 'border-indigo-100 bg-indigo-50 text-indigo-800'}`}>
+        {usingSample
+          ? <>Seeded sample — live <code>/metrics/places/entity-kind</code> needs an authed session.</>
+          : <>Live from <code>/metrics/places/entity-kind</code>.</>}
+      </div>
+
+      <div className="mb-6 p-3 rounded border border-gray-200 bg-gray-50 text-xs text-gray-600 leading-relaxed">
+        <span className="font-medium text-gray-700">entity_kind is derived, not persisted.</span>{' '}
+        <code>brandClassifier.js</code> classifies at ingest (Redis-cached); the seeded Wikidata catalog
+        never ran it, so these figures are derived from metadata markers —
+        <span className="text-amber-700"> chain</span> = <code>is_chain='true'</code>,
+        <span className="text-indigo-700"> brand</span> = <code>thing_level='brand'</code>,
+        <span className="text-emerald-700"> destination</span> = default. A live re-classified
+        distribution would need a backfill (out of scope for the read-only #470).
+      </div>
+
+      <div className="grid grid-cols-4 gap-4 mb-6">
+        <StatCard label="Place Things" value={fmtInt(total)} />
+        <StatCard label="Destinations" value={fmtInt(kindCount('destination'))} detail={`${fmtPct(kindCount('destination'), total)} of places`} />
+        <StatCard label="Brands" value={fmtInt(kindCount('brand'))} detail={fmtPct(kindCount('brand'), total)} />
+        <StatCard label="Chains" value={fmtInt(kindCount('chain'))} detail={fmtPct(kindCount('chain'), total)} />
+      </div>
+
+      {/* entity_kind distribution */}
+      <div className="mb-6 bg-white rounded-lg border border-gray-200 p-4">
+        <div className="text-sm font-medium text-gray-700 mb-3">entity_kind distribution</div>
+        <div className="flex h-3 rounded overflow-hidden bg-gray-100">
+          {byKind.map(r => (
+            <div
+              key={r.entity_kind}
+              className={kindMeta(r.entity_kind).bar}
+              style={{ width: `${rawPct(r.count, total)}%` }}
+              title={`${kindMeta(r.entity_kind).label}: ${fmtInt(r.count)} (${fmtPct(r.count, total)})`}
+            />
+          ))}
+        </div>
+        <div className="mt-3 flex flex-wrap gap-x-5 gap-y-2">
+          {byKind.map(r => (
+            <div key={r.entity_kind} className="flex items-center gap-1.5 text-xs">
+              <span className={`w-2.5 h-2.5 rounded-sm ${kindMeta(r.entity_kind).bar}`} />
+              <span className="text-gray-700 font-medium">{kindMeta(r.entity_kind).label}</span>
+              <span className="text-gray-400 tabular-nums">{fmtInt(r.count)} · {fmtPct(r.count, total)}</span>
+            </div>
+          ))}
+        </div>
+        <p className="mt-3 text-xs text-gray-400">
+          A destination-dominant catalog is the “curation, not directory” thesis (#456) holding —
+          notable places worth an opinion, not franchise access-points.
+        </p>
+      </div>
+
+      {/* by type */}
+      {typeRows.length > 0 && (
+        <div className="mb-6 bg-white rounded-lg border border-gray-200 p-4">
+          <div className="text-sm font-medium text-gray-700 mb-3">By type</div>
+          <table className="w-full text-xs">
+            <thead>
+              <tr className="text-gray-400 uppercase text-left">
+                <th className="py-1.5 font-medium">Type</th>
+                {KIND_ORDER.map(k => (
+                  <th key={k} className="py-1.5 font-medium text-right">{kindMeta(k).label}</th>
+                ))}
+                <th className="py-1.5 font-medium text-right">Total</th>
+              </tr>
+            </thead>
+            <tbody>
+              {typeRows.map(row => (
+                <tr key={row.type} className="border-t border-gray-100">
+                  <td className="py-1.5 text-gray-700 font-medium">{row.type}</td>
+                  {KIND_ORDER.map(k => (
+                    <td key={k} className="py-1.5 text-right tabular-nums text-gray-600">
+                      {row.kinds[k] ? fmtInt(row.kinds[k]) : <span className="text-gray-300">—</span>}
+                    </td>
+                  ))}
+                  <td className="py-1.5 text-right tabular-nums text-gray-900 font-medium">{fmtInt(row.totalForType)}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </div>
+      )}
+
+      {/* chain-location pollution (#462) */}
+      <div className="bg-white rounded-lg border border-gray-200 p-4">
+        <div className="flex items-center justify-between gap-2">
+          <div className="text-sm font-medium text-gray-700">
+            Chain-location pollution <span className="text-gray-400 font-normal">· #462</span>
+          </div>
+          <span className={`text-xs font-medium px-1.5 py-0.5 rounded ${candidateTotal === 0 ? 'text-green-700 bg-green-50' : 'text-amber-700 bg-amber-50'}`}>
+            {fmtInt(candidateTotal)} candidate{candidateTotal === 1 ? '' : 's'}
+          </span>
+        </div>
+
+        {candidateTotal === 0 ? (
+          <p className="mt-2 text-xs text-gray-500 leading-relaxed">
+            No Restaurant/Hotel Things carry a <code>google_place_id</code> + chain flag — there is no
+            chain-location pollution, so the #462 prune stays deferred with data behind it. Under #459
+            chains no longer acquire a <code>place_id</code>, so this only tracks legacy pollution.
+          </p>
+        ) : (
+          <>
+            <p className="mt-2 text-xs text-gray-500 leading-relaxed">
+              Restaurant/Hotel Things carrying a <code>google_place_id</code> + a recognized chain brand —
+              merge-into-brand candidates (#456 migration notes / #462).
+            </p>
+            {(candidates.by_type || []).length > 0 && (
+              <div className="mt-2 flex flex-wrap gap-2">
+                {candidates.by_type.map(t => (
+                  <span key={t.type} className="text-[11px] px-1.5 py-0.5 rounded bg-amber-50 text-amber-700">
+                    {t.type} · <span className="tabular-nums">{fmtInt(t.count)}</span>
+                  </span>
+                ))}
+              </div>
+            )}
+            {(candidates.sample || []).length > 0 && (
+              <table className="mt-3 w-full text-xs">
+                <thead>
+                  <tr className="text-gray-400 uppercase text-left">
+                    <th className="py-1.5 font-medium">Title</th>
+                    <th className="py-1.5 font-medium">Type</th>
+                    <th className="py-1.5 font-medium">Chain brand</th>
+                    <th className="py-1.5 font-medium">Place ID</th>
+                  </tr>
+                </thead>
+                <tbody>
+                  {candidates.sample.map(s => (
+                    <tr key={s.thing_id} className="border-t border-gray-100">
+                      <td className="py-1.5 text-gray-700 font-medium">{s.title || <span className="text-gray-300">—</span>}</td>
+                      <td className="py-1.5 text-gray-500">{s.type}</td>
+                      <td className="py-1.5 text-gray-500">{s.chain_brand || '—'}</td>
+                      <td className="py-1.5 text-gray-400 font-mono text-[11px]">{s.google_place_id || '—'}</td>
+                    </tr>
+                  ))}
+                </tbody>
+              </table>
+            )}
+          </>
+        )}
+      </div>
+    </>
+  );
+}

--- a/src/pages/places/mockPlaces.js
+++ b/src/pages/places/mockPlaces.js
@@ -1,0 +1,56 @@
+// Seeded sample for the Places monitor (#470 · B1+B2). Mirrors the live
+// GET /metrics/places/entity-kind shape so the page is demoable/verifiable
+// offline; replaced by live data when the endpoint is reachable.
+//
+// NOTE: entity_kind is DERIVED from metadata markers, not a persisted
+// classifier verdict — the seeded Wikidata catalog never ran brandClassifier.js
+// and defaults to 'destination'. Distribution figures mirror prod (2026-07-16).
+// The chain_location_candidates rows are illustrative (live prod total is 0) so
+// the populated table state is visible in the sample.
+export const MOCK_PLACES = {
+  places_total: 29607,
+  by_entity_kind: [
+    { entity_kind: 'destination', count: 29603 },
+    { entity_kind: 'chain', count: 3 },
+    { entity_kind: 'brand', count: 1 },
+  ],
+  by_type_kind: [
+    { type: 'Museum', entity_kind: 'destination', count: 8649 },
+    { type: 'Hotel', entity_kind: 'destination', count: 8555 },
+    { type: 'Hotel', entity_kind: 'chain', count: 2 },
+    { type: 'TouristAttraction', entity_kind: 'destination', count: 7883 },
+    { type: 'Park', entity_kind: 'destination', count: 3086 },
+    { type: 'Restaurant', entity_kind: 'destination', count: 1424 },
+    { type: 'Restaurant', entity_kind: 'brand', count: 1 },
+    { type: 'Restaurant', entity_kind: 'chain', count: 1 },
+  ],
+  chain_location_candidates: {
+    total: 2,
+    by_type: [
+      { type: 'Hotel', count: 1 },
+      { type: 'Restaurant', count: 1 },
+    ],
+    sample: [
+      {
+        thing_id: 'hotel_courtyard_marriott_downtown_a1b2',
+        title: 'Courtyard by Marriott Downtown',
+        type: 'Hotel',
+        chain_brand: 'Marriott',
+        google_place_id: 'ChIJexample_marriott',
+      },
+      {
+        thing_id: 'restaurant_wendys_123_main_c3d4',
+        title: "Wendy's — 123 Main St",
+        type: 'Restaurant',
+        chain_brand: "Wendy's",
+        google_place_id: 'ChIJexample_wendys',
+      },
+    ],
+  },
+  derivation: {
+    chain: "metadata.is_chain = 'true'",
+    brand: "metadata.thing_level = 'brand' (and not a chain)",
+    destination: 'any other Place-parented Thing (default)',
+    persisted: false,
+  },
+};

--- a/src/pages/scorecard/ScorecardPage.jsx
+++ b/src/pages/scorecard/ScorecardPage.jsx
@@ -64,6 +64,56 @@ function MetricTile({ label, current, baseline, format, higherIsBetter, sparklin
   );
 }
 
+// Canonical-ID coverage — dual metric (any + strong) from #414's stable field.
+function CoverageTile({ anyPct, strongPct }) {
+  const cols = [
+    { key: 'any', label: 'any ID', current: anyPct, baseline: BASELINE.canonicalIdAnyPct },
+    { key: 'strong', label: 'authoritative', current: strongPct, baseline: BASELINE.canonicalIdStrongPct },
+  ];
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 flex flex-col">
+      <div className="text-sm text-gray-500">Canonical-ID coverage</div>
+      <div className="mt-2 flex items-start gap-6">
+        {cols.map(c => (
+          <div key={c.key}>
+            <div className="flex items-baseline gap-1.5">
+              <span className="text-2xl font-semibold text-gray-900 tabular-nums">{fmt(c.current, 'pct')}</span>
+              <Delta current={c.current} baseline={c.baseline} higherIsBetter format="pct" />
+            </div>
+            <div className="mt-0.5 text-xs text-gray-400">
+              {c.label} · baseline <span className="tabular-nums text-gray-500">{fmt(c.baseline, 'pct')}</span>
+            </div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+// Work structure — positive-structure counts from the weekly snapshot (#418).
+function StructureTile({ worksTotal, worksMulti, editionsLinked }) {
+  const stats = [
+    { label: 'Works', value: worksTotal, title: 'Distinct Works' },
+    { label: 'Multi-ed.', value: worksMulti, title: 'Works with 2+ linked editions' },
+    { label: 'Linked', value: editionsLinked, title: 'Editions linked to a Work' },
+  ];
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 p-4 flex flex-col">
+      <div className="text-sm text-gray-500">Work structure</div>
+      <div className="mt-2 grid grid-cols-3 gap-2">
+        {stats.map(s => (
+          <div key={s.label} title={s.title}>
+            <div className="text-2xl font-semibold text-gray-900 tabular-nums">
+              {s.value == null ? '—' : Number(s.value).toLocaleString()}
+            </div>
+            <div className="mt-0.5 text-xs text-gray-400">{s.label}</div>
+          </div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
 // ER precision/recall/F1 from the eval (#400/#421), with provenance badge.
 function ErEvalTile({ precision, recall, f1, source, sparkline }) {
   const live = precision != null || recall != null || f1 != null;
@@ -217,7 +267,10 @@ export default function ScorecardPage() {
   const erF1Trend = snapshots.map(s => numberOrNull(s.metrics?.er_f1)).filter(v => v != null);
   const fragmentationPct = numberOrNull(latestSnap.fragmentation_pct);
   const fragmentationTrend = snapshots.map(s => numberOrNull(s.fragmentation_pct)).filter(v => v != null);
+  // Positive Work-structure counts added to the snapshot JSONB by #418.
   const editionsLinked = numberOrNull(snapMetrics.editions_linked);
+  const worksTotal = numberOrNull(snapMetrics.works_total);
+  const worksMultiEdition = numberOrNull(snapMetrics.works_multi_edition);
 
   const overall = quality.data?.overall || {};
   const distribution = quality.data?.distribution || [];
@@ -230,13 +283,12 @@ export default function ScorecardPage() {
     overall.total_things,
   );
 
-  // Canonical-ID coverage (any) — backend key not yet firm; try a few shapes.
-  const canonicalAnyPct = numberOrNull(
-    dedupData.canonical_id_coverage_pct,
-    dedupData.canonical_coverage_pct,
-    dedupData.coverage_pct,
-    dedupData.canonical_id_any_pct,
-  );
+  // Canonical-ID coverage — #414 shipped a stable documented field with any + strong
+  // flavours (canonical_id_coverage.{any_pct,strong_pct}); the flat *_pct keys are
+  // back-compat aliases for "any".
+  const coverage = dedupData.canonical_id_coverage || {};
+  const canonicalAnyPct = numberOrNull(coverage.any_pct, dedupData.canonical_id_coverage_pct);
+  const canonicalStrongPct = numberOrNull(coverage.strong_pct, dedupData.canonical_id_strong_pct);
 
   // Extraction quality average (0..1)
   const extractionAvg = numberOrNull(overall.avg_quality);
@@ -297,14 +349,7 @@ export default function ScorecardPage() {
           higherIsBetter
           color="#6366f1"
         />
-        <MetricTile
-          label="Canonical-ID coverage (any)"
-          current={canonicalAnyPct}
-          baseline={BASELINE.canonicalIdAnyPct}
-          format="pct"
-          higherIsBetter
-          color="#10b981"
-        />
+        <CoverageTile anyPct={canonicalAnyPct} strongPct={canonicalStrongPct} />
         <MetricTile
           label="Extraction quality (avg)"
           current={extractionAvg}
@@ -330,7 +375,7 @@ export default function ScorecardPage() {
       <div className="grid grid-cols-4 gap-4 mb-6">
         <ErEvalTile precision={erPrecision} recall={erRecall} f1={erF1} source={erSource} sparkline={erF1Trend} />
         <MetricTile
-          label="Edition fragmentation rate"
+          label="Edition fragmentation (unresolved)"
           current={fragmentationPct}
           baseline={BASELINE.editionFragmentationBooksPct}
           format="pct"
@@ -338,13 +383,10 @@ export default function ScorecardPage() {
           sparkline={fragmentationTrend}
           color="#f59e0b"
         />
-        <MetricTile
-          label="Editions linked to a Work"
-          current={editionsLinked}
-          baseline={null}
-          format="count"
-          higherIsBetter
-          color="#6366f1"
+        <StructureTile
+          worksTotal={worksTotal}
+          worksMulti={worksMultiEdition}
+          editionsLinked={editionsLinked}
         />
       </div>
 

--- a/src/pages/search-quality/SearchQualityPage.jsx
+++ b/src/pages/search-quality/SearchQualityPage.jsx
@@ -1,7 +1,9 @@
 import { useState } from 'react';
 import PageHeader from '../../components/PageHeader';
 import { useHybridSearch } from '../../api/hooks';
-import { MOCK_HYBRID } from './mockSearch';
+import { mockFor } from './mockSearch';
+
+const isPersonType = t => /^person$/i.test(t || '');
 
 const JUDGE_KEY = 'searchJudgments_v1';
 
@@ -36,14 +38,67 @@ function ResultRow({ rank, r, relevance, onJudge }) {
   );
 }
 
+// Type distribution over the result set — makes the #429 "Person floods
+// type-implied queries" regression observable (backend returns no facets here,
+// so it's computed client-side from the ranked results).
+export function TypeDistribution({ facets, total, personFlood }) {
+  const max = facets[0]?.count || 1;
+  return (
+    <div className="mb-4 bg-white rounded-lg border border-gray-200 p-4">
+      <div className="flex items-center justify-between mb-2">
+        <h2 className="text-sm font-medium text-gray-700">
+          Type distribution <span className="text-gray-400 font-normal">· {total} results</span>
+        </h2>
+        {personFlood && (
+          <span className="text-xs font-medium text-amber-700 bg-amber-50 px-1.5 py-0.5 rounded">
+            Person-dominated · likely #429
+          </span>
+        )}
+      </div>
+      <div className="space-y-1">
+        {facets.map(f => {
+          const person = isPersonType(f.type);
+          const share = total ? (f.count / total) * 100 : 0;
+          return (
+            <div key={f.type} className="flex items-center gap-2 text-xs">
+              <span className={`w-28 shrink-0 truncate ${person ? 'text-amber-700 font-medium' : 'text-gray-600'}`}>{f.type}</span>
+              <div className="flex-1 h-2 bg-gray-100 rounded overflow-hidden">
+                <div className={`h-full ${person ? 'bg-amber-400' : 'bg-indigo-400'}`} style={{ width: `${(f.count / max) * 100}%` }} />
+              </div>
+              <span className="w-20 text-right tabular-nums text-gray-400">{f.count} · {share.toFixed(0)}%</span>
+            </div>
+          );
+        })}
+      </div>
+      {personFlood && (
+        <p className="mt-2 text-[11px] text-gray-400">
+          Actors matching transitively via credits (“known for”) outrank the implied type — the #429
+          regression. Judge the Person rows ✗ to capture it in the golden set.
+        </p>
+      )}
+    </div>
+  );
+}
+
 export default function SearchQualityPage() {
   const [input, setInput] = useState('');
   const [query, setQuery] = useState('');
   const live = useHybridSearch(query);
 
-  const data = live.data?.results ? live.data : (query ? MOCK_HYBRID : null);
+  const data = live.data?.results ? live.data : (query ? mockFor(query) : null);
   const usingSample = !!query && !live.data?.results;
   const results = data?.results || [];
+
+  // Type distribution (client-side facets) for the #429 Person-flood signal.
+  const facetCounts = results.reduce((acc, r) => {
+    const t = r.type || 'unknown';
+    acc[t] = (acc[t] || 0) + 1;
+    return acc;
+  }, {});
+  const facets = Object.entries(facetCounts)
+    .map(([type, count]) => ({ type, count }))
+    .sort((a, b) => b.count - a.count);
+  const personFlood = results.length >= 5 && facets[0] && isPersonType(facets[0].type);
 
   const [judgments, setJudgments] = useState(loadJudgments);
   const judged = judgments[query] || {};
@@ -76,7 +131,7 @@ export default function SearchQualityPage() {
     <>
       <PageHeader
         title="Search Quality Inspector"
-        description="Run a query, compare lexical vs hybrid (RRF) ranking, and mark relevance to build the semantic-recall golden query set (#406 → #400)."
+        description="Run a query, see its type distribution (the #429 Person-flood signal), compare lexical vs hybrid (RRF) ranking, and mark relevance to build the semantic-recall golden query set (#406 → #400)."
       />
 
       <form
@@ -107,6 +162,8 @@ export default function SearchQualityPage() {
               : <>Live <code>/search/hybrid</code> · mode <span className="font-medium">{data.mode}</span> · {data.count} results.</>}
             {' '}<span className="text-violet-600">{semanticWins} semantic-only win(s)</span> the lexical ranker missed.
           </div>
+
+          <TypeDistribution facets={facets} total={results.length} personFlood={personFlood} />
 
           <div className="grid grid-cols-2 gap-4">
             <div className="bg-white rounded-lg border border-gray-200 p-4">

--- a/src/pages/search-quality/mockSearch.js
+++ b/src/pages/search-quality/mockSearch.js
@@ -15,3 +15,35 @@ export const MOCK_HYBRID = {
     { thing_id: 't-d7', display_name: 'The Spice Must Flow', type: 'book', _fusion: { rrf: 0.0142, lexical_rank: 14, vector_rank: 9 } },
   ],
 };
+
+// A type-implied query ("Best TV Series") flooded by Person records that match
+// transitively via credits — the #429 regression. Used so the type-distribution
+// panel demonstrates the Person-dominated case offline (see mockFor).
+export const MOCK_TV_SERIES = {
+  mode: 'hybrid',
+  query: 'best tv series',
+  count: 13,
+  results: [
+    { thing_id: 't-s1', display_name: 'Black Mirror', type: 'TVSeries', _fusion: { rrf: 0.0305, lexical_rank: 1, vector_rank: 2 } },
+    { thing_id: 't-s2', display_name: 'Westworld', type: 'TVSeries', _fusion: { rrf: 0.0291, lexical_rank: 2, vector_rank: 6 } },
+    { thing_id: 't-p1', display_name: 'Ed Speleers', type: 'Person', _fusion: { rrf: 0.0270, lexical_rank: 3, vector_rank: null } },
+    { thing_id: 't-s3', display_name: 'Humans', type: 'TVSeries', _fusion: { rrf: 0.0262, lexical_rank: 4, vector_rank: 8 } },
+    { thing_id: 't-p2', display_name: 'Şükrü Özyıldız', type: 'Person', _fusion: { rrf: 0.0244, lexical_rank: 5, vector_rank: null } },
+    { thing_id: 't-s4', display_name: 'Arrested Development', type: 'TVSeries', _fusion: { rrf: 0.0231, lexical_rank: 6, vector_rank: 11 } },
+    { thing_id: 't-p3', display_name: 'Carson MacCormac', type: 'Person', _fusion: { rrf: 0.0210, lexical_rank: 7, vector_rank: null } },
+    { thing_id: 't-p4', display_name: 'Lauren Tom', type: 'Person', _fusion: { rrf: 0.0198, lexical_rank: 8, vector_rank: null } },
+    { thing_id: 't-p5', display_name: 'Michael McDonald', type: 'Person', _fusion: { rrf: 0.0187, lexical_rank: 9, vector_rank: null } },
+    { thing_id: 't-p6', display_name: 'Isaac Hempstead Wright', type: 'Person', _fusion: { rrf: 0.0175, lexical_rank: 10, vector_rank: null } },
+    { thing_id: 't-sg1', display_name: 'Best (song)', type: 'Song', _fusion: { rrf: 0.0142, lexical_rank: 12, vector_rank: null } },
+    { thing_id: 't-b1', display_name: 'Best Buy', type: 'Brand', _fusion: { rrf: 0.0121, lexical_rank: 15, vector_rank: null } },
+    { thing_id: 't-p7', display_name: 'Elisabeth Röhm', type: 'Person', _fusion: { rrf: 0.0110, lexical_rank: 18, vector_rank: null } },
+  ],
+};
+
+// Pick the seeded sample that best illustrates the query: the Person-flooded
+// set for type-implied queries ("best tv series", "top movies", …), else dune.
+export function mockFor(query) {
+  const q = (query || '').toLowerCase();
+  const typeImplied = /(tv series|tv shows|\b(best|top)\b.*\b(movies|albums|books|shows|series|songs)\b)/.test(q);
+  return typeImplied ? MOCK_TV_SERIES : MOCK_HYBRID;
+}

--- a/src/pages/triage/TriagePage.jsx
+++ b/src/pages/triage/TriagePage.jsx
@@ -1,7 +1,76 @@
 import { useState, useMemo } from 'react';
 import PageHeader from '../../components/PageHeader';
-import { useLowQualityThings, useReEnrich } from '../../api/hooks';
-import { MOCK_LOW_QUALITY } from './mockLowQuality';
+import { useLowQualityThings, useReEnrich, useReEnrichSweepStatus } from '../../api/hooks';
+import { MOCK_LOW_QUALITY, MOCK_SWEEP } from './mockLowQuality';
+
+function fmtDate(v) {
+  if (!v) return '—';
+  const d = new Date(v);
+  return Number.isNaN(d.getTime()) ? '—' : d.toLocaleString();
+}
+
+// Read-only quality-tail re-enrich sweep status (#473 / #420). No kill switch /
+// start button — the sweep is a manual CLI, not a daemon.
+function SweepPanel({ sweep, isSample }) {
+  if (!sweep || sweep.available === false) {
+    return (
+      <div className="mb-4 bg-white rounded-lg border border-dashed border-gray-200 p-4">
+        <div className="flex items-center justify-between">
+          <h2 className="text-sm font-medium text-gray-700">Quality-tail sweep</h2>
+          <span className="text-xs font-medium text-amber-700 bg-amber-50 px-1.5 py-0.5 rounded">awaiting deploy</span>
+        </div>
+        <p className="mt-2 text-xs text-gray-400">
+          Bulk worst-first re-enrich (#420). Live once <code>/admin/re-enrich/sweep/status</code> reports <code>available</code>.
+        </p>
+      </div>
+    );
+  }
+  const processed = sweep.processed || 0;
+  const remaining = sweep.remaining_candidates || 0;
+  const totalPool = processed + remaining;
+  const pct = totalPool > 0 ? (processed / totalPool) * 100 : 0;
+  const delta = sweep.avg_quality_delta;
+  const outcomes = sweep.outcomes || {};
+  return (
+    <div className="mb-4 bg-white rounded-lg border border-gray-200 p-4">
+      <div className="flex items-center justify-between gap-2 mb-2">
+        <div className="flex items-center gap-2">
+          <h2 className="text-sm font-medium text-gray-700">Quality-tail sweep</h2>
+          <span className="text-[11px] px-1.5 py-0.5 rounded bg-gray-100 text-gray-500">manual CLI</span>
+          {isSample && <span className="text-[11px] px-1.5 py-0.5 rounded bg-amber-50 text-amber-700">sample</span>}
+        </div>
+        <span className="text-xs text-gray-400">last run {fmtDate(sweep.last_run_at)}</span>
+      </div>
+      <div className="flex items-center gap-3">
+        <div className="flex-1 h-2.5 bg-gray-100 rounded overflow-hidden">
+          <div className="h-full bg-indigo-400 rounded" style={{ width: `${Math.min(pct, 100)}%` }} />
+        </div>
+        <span className="text-xs tabular-nums text-gray-500">{processed.toLocaleString()} / {totalPool.toLocaleString()}</span>
+      </div>
+      <div className="mt-3 grid grid-cols-4 gap-3 text-xs">
+        <div>
+          <div className="text-lg font-semibold text-gray-900 tabular-nums">{remaining.toLocaleString()}</div>
+          <div className="text-gray-400">remaining</div>
+        </div>
+        <div>
+          <div className={`text-lg font-semibold tabular-nums ${delta > 0 ? 'text-green-700' : 'text-gray-900'}`}>
+            {delta == null ? '—' : `${delta > 0 ? '+' : ''}${Number(delta).toFixed(2)}`}
+          </div>
+          <div className="text-gray-400">avg quality Δ</div>
+        </div>
+        <div>
+          <div className="text-lg font-semibold text-gray-900 tabular-nums">{(outcomes.improved ?? 0).toLocaleString()}</div>
+          <div className="text-gray-400">improved</div>
+        </div>
+        <div>
+          <div className="text-lg font-semibold text-gray-900 tabular-nums">{(outcomes.merged ?? 0).toLocaleString()}</div>
+          <div className="text-gray-400">merged</div>
+        </div>
+      </div>
+      <p className="mt-2 text-[11px] text-gray-400">Read-only — kicked from a CLI, never touches list memberships. Δ feeds the scorecard <code>low_quality_pct</code>.</p>
+    </div>
+  );
+}
 
 const ISSUE_LABEL = {
   missing_title: 'missing title',
@@ -10,6 +79,7 @@ const ISSUE_LABEL = {
   low_enrichment: 'low enrichment',
   uncertain_type: 'uncertain type',
   general_low_quality: 'general',
+  person_as_content: 'person-as-content',
 };
 const ISSUE_CLS = {
   missing_title: 'bg-red-50 text-red-700',
@@ -18,27 +88,41 @@ const ISSUE_CLS = {
   low_enrichment: 'bg-yellow-50 text-yellow-700',
   uncertain_type: 'bg-violet-50 text-violet-700',
   general_low_quality: 'bg-gray-100 text-gray-600',
+  person_as_content: 'bg-rose-50 text-rose-700',
 };
 
 export default function TriagePage() {
+  const [typeFilter, setTypeFilter] = useState('');
+  const [issueFilter, setIssueFilter] = useState('');
+  const [status, setStatus] = useState({}); // thing_id -> 'queued' | 'done' | 'failed'
+
   const query = useLowQualityThings();
   const reEnrich = useReEnrich();
+  const sweepQuery = useReEnrichSweepStatus();
+  const sweep = sweepQuery.data || MOCK_SWEEP;
+  const sweepIsSample = !sweepQuery.data;
+  // person_as_content is quality-independent, so it's fetched server-side on demand
+  // (?issue=person_as_content) rather than filtered from the quality<0.5 tail.
+  const personActive = issueFilter === 'person_as_content';
+  const personQuery = useLowQualityThings({ issue: 'person_as_content', minQuality: 1, enabled: personActive });
 
   const live = query.data && query.data.things ? query.data : null;
   const usingSample = !live;
   const data = live || MOCK_LOW_QUALITY;
   const things = useMemo(() => data.things || [], [data]);
   const breakdown = data.issue_breakdown || [];
+  const heuristics = data.heuristics || {};
 
-  const [typeFilter, setTypeFilter] = useState('');
-  const [issueFilter, setIssueFilter] = useState('');
-  const [status, setStatus] = useState({}); // thing_id -> 'queued' | 'done' | 'failed'
+  // Show server-filtered person rows when that chip is active; otherwise the tail.
+  // Fallback filters the loaded set (sample mode / while the server query loads).
+  const personThings = personQuery.data?.things ?? things.filter(t => t.primary_issue === 'person_as_content');
+  const displayThings = personActive ? personThings : things;
 
-  const types = useMemo(() => [...new Set(things.map(t => t.type))].sort(), [things]);
+  const types = useMemo(() => [...new Set(displayThings.map(t => t.type))].sort(), [displayThings]);
 
   const rows = useMemo(
-    () => things.filter(t => (!typeFilter || t.type === typeFilter) && (!issueFilter || t.primary_issue === issueFilter)),
-    [things, typeFilter, issueFilter],
+    () => displayThings.filter(t => (!typeFilter || t.type === typeFilter) && (personActive || !issueFilter || t.primary_issue === issueFilter)),
+    [displayThings, typeFilter, issueFilter, personActive],
   );
 
   async function triage(thing) {
@@ -64,12 +148,15 @@ export default function TriagePage() {
           : <>Live tail from <code>/metrics/low-quality-things</code>.</>}
       </div>
 
+      <SweepPanel sweep={sweep} isSample={sweepIsSample} />
+
       {/* Issue breakdown */}
       <div className="mb-4 flex flex-wrap gap-2">
         {breakdown.map(b => (
           <button
             key={b.issue}
             onClick={() => setIssueFilter(issueFilter === b.issue ? '' : b.issue)}
+            title={b.issue === 'person_as_content' ? heuristics.person_as_content : undefined}
             className={`text-xs px-2 py-1 rounded border ${issueFilter === b.issue ? 'border-indigo-400 ring-1 ring-indigo-300' : 'border-gray-200'} ${ISSUE_CLS[b.issue] || 'bg-gray-100 text-gray-600'}`}
           >
             {ISSUE_LABEL[b.issue] || b.issue} · <span className="tabular-nums">{Number(b.count).toLocaleString()}</span>
@@ -88,6 +175,13 @@ export default function TriagePage() {
         )}
         <span className="text-gray-400 ml-auto tabular-nums">{rows.length} shown</span>
       </div>
+
+      {personActive && (
+        <div className="mb-3 -mt-1 text-[11px] text-rose-700 bg-rose-50 border border-rose-100 rounded px-2 py-1.5">
+          Quality-independent — these are wrong-<em>type</em> mistypes (article bylines extracted as a Person, #442),
+          surfaced regardless of quality score. ~0 expected today; the chip lights up on regressions. Re-enrich re-runs the pipeline.
+        </div>
+      )}
 
       {/* Queue */}
       <div className="bg-white rounded-lg border border-gray-200 p-4">

--- a/src/pages/triage/mockLowQuality.js
+++ b/src/pages/triage/mockLowQuality.js
@@ -11,6 +11,10 @@ export const MOCK_LOW_QUALITY = {
     { thing_id: 't-lq-6', type: 'book', title: 'Atomic Habits (intl ed.)', quality_score: 0.48, type_confidence: 0.93, enrichment_coverage: 0.41, usage_count: 49, primary_issue: 'general_low_quality', priority_score: 25.48 },
     { thing_id: 't-lq-7', type: 'game', title: '', quality_score: 0.19, type_confidence: 0.6, enrichment_coverage: 0.12, usage_count: 27, primary_issue: 'missing_title', priority_score: 21.87 },
     { thing_id: 't-lq-8', type: 'movie', title: 'Inception', quality_score: 0.44, type_confidence: 0.49, enrichment_coverage: 0.33, usage_count: 31, primary_issue: 'uncertain_type', priority_score: 17.36 },
+    // Person-as-content mistypes (#442) — decent quality_score, wrong TYPE; these
+    // don't appear in the quality<0.5 tail, only under ?issue=person_as_content.
+    { thing_id: 't-pac-1', type: 'Person', title: 'S.J. Scott', quality_score: 0.66, type_confidence: 0.82, enrichment_coverage: 0.5, usage_count: 12, primary_issue: 'person_as_content', priority_score: 4.08 },
+    { thing_id: 't-pac-2', type: 'Person', title: 'Courtney E. Ackerman', quality_score: 0.71, type_confidence: 0.79, enrichment_coverage: 0.55, usage_count: 6, primary_issue: 'person_as_content', priority_score: 1.74 },
   ],
   issue_breakdown: [
     { issue: 'missing_image', count: 9120 },
@@ -19,5 +23,25 @@ export const MOCK_LOW_QUALITY = {
     { issue: 'uncertain_type', count: 2210 },
     { issue: 'missing_title', count: 1460 },
     { issue: 'general_low_quality', count: 796 },
+    { issue: 'person_as_content', count: 2 },
   ],
+  heuristics: {
+    person_as_content: 'A Person Thing whose source URL is article/listicle-shaped, or that was created via a schema.org author/byline block over a content type (#442). Quality-independent — surfaced regardless of quality_score.',
+  },
+};
+
+// Seeded sample for the quality-tail re-enrich sweep status (#473 / #420).
+// Read-only — the sweep is a manual CLI (mode: 'manual_cli'), not a daemon,
+// so there is no running flag and no start/stop control.
+export const MOCK_SWEEP = {
+  available: true,
+  mode: 'manual_cli',
+  running: null,
+  flag_name: null,
+  processed: 1840,
+  pending: 0,
+  remaining_candidates: 23960,
+  avg_quality_delta: 0.21,
+  last_run_at: '2026-07-15T09:12:00Z',
+  outcomes: { improved: 1520, unchanged: 295, merged: 25 },
 };


### PR DESCRIPTION
First slice of the 2026-07 backlog review (`docs/admin-updates-plan-2026-07.md`) — two independent, self-contained changes.

## A1 + A2 · Scorecard contract fixes (`c8f262b`)
- **A1 (#414):** backend shipped a stable `canonical_id_coverage.{any_pct,strong_pct}` field. Dropped the 4-key defensive probing (`ScorecardPage.jsx`) and read it directly; added the previously-missing **authoritative (strong)** coverage. Both render in a new dual-metric `CoverageTile` (mirrors `ErEvalTile`), keeping the Live row at 4 tiles.
- **A2 (#418):** fragmentation baseline already correct at 8.4% — relabeled the tile **"unresolved"** to reflect the new Work-aware definition, and surfaced the new snapshot structure fields (`works_total`, `works_multi_edition`, `editions_linked`) in a compact `StructureTile`.

## B1 + B2 · New Places monitor (`37adb53`)
Backend endpoint `GET /metrics/places/entity-kind` (tnats/listgem-platform#470) → new `/places` page under Registry:
- **entity_kind distribution** (destination / brand / chain) as a proportion bar + legend.
- **By-type cross-tab** (type × entity_kind).
- **Chain-location pollution panel (#462)** — candidate count + sample table, with an empty-state that states the finding.

Two findings from #470 baked honestly into the UI:
1. `entity_kind` is **derived, not persisted** (seeded Wikidata catalog never ran `brandClassifier.js` → defaults to `destination`) — the page carries a caveat saying so.
2. `chain_location_candidates.total = 0` on prod — no chain-location pollution, so the #462 prune stays deferred *with data*.

## C2 · Search inspector type-distribution (`2d75a14`)
`#429`: Person records flood type-implied queries ("Best TV Series" → 65% actors). Added a `TypeDistribution` panel to the search inspector, computed **client-side** from the ranked results (the hybrid endpoint returns no facets), flagging **"Person-dominated · likely #429"** when Person is the top type. Query-aware seeded sample (`mockFor`/`MOCK_TV_SERIES`) so the flood case demos offline.

## B3 · Taxonomy Health panel (`013b40a`)
Pipeline page gains a **Taxonomy Health** panel. The **retired-type sightings** half is fully live with no backend dependency — computed client-side from `/metrics/quality-by-type`, flagging any #456-retired commodity type (Cafe/Gym/Bar/Store) that still carries Things (**curation-clean** when all zero). Parent-type drift (#441) shows "awaiting backend drift count" until a server-side field lands.

## C1 / D1 / D2 · Wiring the #476 backend hand-off (`add9115`)
The backend team shipped the endpoints (backend #472/#473/#474) and consolidated the contracts in **#476**. Render layer built:
- **C1** — Triage `person-as-content` chip. Quality-independent, so it fetches server-side via `?issue=person_as_content` (not the quality<0.5 tail); heuristic on hover; "~0 today, lights up on regressions" note.
- **D1** — Triage **read-only** quality-tail sweep panel (progress, `avg_quality_delta`, outcomes, "manual CLI" badge). No kill switch / start button — the sweep is a manual CLI, not a daemon; `available:false` → "awaiting deploy".
- **D2** — Image Quality: "Broken Images" card (fills as the daily dead-link sweep runs), Commons normalization bar (100% "done"), per-type Broken column.

## Verification
- `eslint` clean, `vite build` succeeds.
- Search inspector, Taxonomy Health, and the C1/D1/D2 panels verified with SSR smoke tests (facets; taxonomy states; person chip + heuristic; read-only sweep + awaiting; broken/Commons image fields).
- **Note:** the two `/admin/*` endpoints (D1, D2) haven't been smoke-tested through admin auth on the deployed service (per #476) — worth a quick admin-token check as a first render-review step; no admin credential is available in the dev environment here.
- Places page additionally verified with an SSR smoke-render of the seeded-sample path (distribution, cross-tab, populated candidate table).
- Live-render of both pages needs an authed backend session (unavailable in the dev environment); the scorecard tiles read from live `/metrics/*`, the Places page from `/metrics/places/entity-kind` with seeded-sample fallback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


