### PR TITLE
Pin empty-live-state; stop painting fixtures while the request is in flight

### DIFF
--- a/src/pages/concierge/OutreachBoardPage.jsx
+++ b/src/pages/concierge/OutreachBoardPage.jsx
@@ -77,9 +77,12 @@ export default function OutreachBoardPage() {
   const query = usePitches({ assignedTo });
   const { setStatus } = usePitchMutations();
 
+  // Don't paint the sample while the request is still in flight: for that beat
+  // the board would show seven invented people, with example.* contacts, in the
+  // place staff read as "who we contact next". Empty until we know.
   const live = query.data?.pitches;
-  const usingSample = !live;
-  const all = usingSample ? MOCK_PITCHES : live;
+  const usingSample = !query.isLoading && !live;
+  const all = live || (usingSample ? MOCK_PITCHES : []);
   const pitches = all.filter(
     p =>
       (!statusFilter || p.status === statusFilter) &&
@@ -113,12 +116,16 @@ export default function OutreachBoardPage() {
 
       <div
         className={`mb-4 rounded border p-3 text-xs ${
-          usingSample
-            ? 'border-amber-200 bg-amber-50 text-amber-800'
-            : 'border-indigo-100 bg-indigo-50 text-indigo-800'
+          query.isLoading
+            ? 'border-gray-200 bg-gray-50 text-gray-500'
+            : usingSample
+              ? 'border-amber-200 bg-amber-50 text-amber-800'
+              : 'border-indigo-100 bg-indigo-50 text-indigo-800'
         }`}
       >
-        {usingSample ? (
+        {query.isLoading ? (
+          <>Loading the live board from <code>/pitches</code>…</>
+        ) : usingSample ? (
           <>
             Seeded sample — live <code>/pitches</code> not reachable from here. Actions POST best-effort and
             report what the API said. No real contact details are in the sample.

--- a/src/pages/concierge/OutreachBoardPage.test.jsx
+++ b/src/pages/concierge/OutreachBoardPage.test.jsx
@@ -3,6 +3,8 @@ import { screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
 import client from '../../api/client';
 import OutreachBoardPage from './OutreachBoardPage';
+import { MOCK_PITCHES } from './mockPitches';
+import { BOARD_COLUMNS } from './pitchRules';
 
 vi.mock('../../api/client', () => ({
   default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -35,6 +37,44 @@ function serve(pitches) {
       : Promise.reject(new Error('not mocked')),
   );
 }
+
+describe('outreach board — an empty live list is not a missing one', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+  });
+
+  // pitch_lists is legitimately empty in prod (listgem-platform#536 deleted the
+  // last fixtures). The other read-only pages in this repo treat an empty array
+  // as "fall back to the sample" — here that would put seven invented people
+  // with example.* contacts on the board that decides who staff contact next.
+  // Empty means empty.
+  it('shows nothing rather than fixtures while the request is in flight', async () => {
+    let settle;
+    client.get.mockReturnValue(new Promise(resolve => { settle = resolve; }));
+    renderWithProviders(<OutreachBoardPage />);
+
+    await screen.findByText(/Loading the live board/i);
+    for (const p of MOCK_PITCHES) {
+      expect(screen.queryByText(p.target_name)).toBeNull();
+    }
+    settle({ data: { pitches: [], count: 0 } });
+    await screen.findByText(/Live board/i);
+  });
+
+  it('renders an empty live board rather than the fixtures', async () => {
+    serve([]);
+    renderWithProviders(<OutreachBoardPage />);
+
+    await screen.findByText(/Live board/i);
+    expect(screen.queryByText(/Seeded sample/i)).toBeNull();
+    // Every column empty — the count text is split across nodes, the columns aren't.
+    expect(screen.getAllByText('empty')).toHaveLength(BOARD_COLUMNS.length);
+    // Not one fixture name may reach the DOM.
+    for (const p of MOCK_PITCHES) {
+      expect(screen.queryByText(p.target_name)).toBeNull();
+    }
+  });
+});
 
 describe('outreach board — re-pitch gating (invariant 1)', () => {
   beforeEach(() => {

--- a/src/pages/moderation/VerificationTool.jsx
+++ b/src/pages/moderation/VerificationTool.jsx
@@ -91,9 +91,11 @@ export default function VerificationTool() {
   const [note, setNote] = useState(null);
 
   const query = useVerifiedUsers({ type, limit: 100 });
+  // As on the outreach board: an in-flight request is not a missing endpoint, so
+  // no fictional verified accounts while we wait.
   const live = query.data?.users || query.data?.verified;
-  const usingSample = !live;
-  const rows = (usingSample ? MOCK_VERIFIED : live).filter(u => !type || u.verified?.type === type);
+  const usingSample = !query.isLoading && !live;
+  const rows = (live || (usingSample ? MOCK_VERIFIED : [])).filter(u => !type || u.verified?.type === type);
 
   const columns = [
     {
@@ -139,10 +141,16 @@ export default function VerificationTool() {
     <>
       <div
         className={`mb-4 rounded border p-3 text-xs ${
-          usingSample ? 'border-amber-200 bg-amber-50 text-amber-800' : 'border-indigo-100 bg-indigo-50 text-indigo-800'
+          query.isLoading
+            ? 'border-gray-200 bg-gray-50 text-gray-500'
+            : usingSample
+              ? 'border-amber-200 bg-amber-50 text-amber-800'
+              : 'border-indigo-100 bg-indigo-50 text-indigo-800'
         }`}
       >
-        {usingSample ? (
+        {query.isLoading ? (
+          <>Loading the live registry from <code>/verification</code>…</>
+        ) : usingSample ? (
           <>
             Seeded sample — live <code>/verification</code> not reachable from here.
           </>

--- a/src/pages/moderation/VerificationTool.test.jsx
+++ b/src/pages/moderation/VerificationTool.test.jsx
@@ -1,0 +1,54 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import client from '../../api/client';
+import VerificationTool from './VerificationTool';
+import { MOCK_VERIFIED } from './mockVerification';
+
+vi.mock('../../api/client', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+describe('verification tool — an empty live list is not a missing one', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+  });
+
+  // Prod answers `{ users: [], count: 0 }` today: nobody is verified yet. Falling
+  // back to the sample here would show three fictional accounts as holding a
+  // real badge, which is the one thing a verification registry must never do.
+  it('shows nothing rather than fixtures while the request is in flight', async () => {
+    let settle;
+    client.get.mockReturnValue(new Promise(resolve => { settle = resolve; }));
+    renderWithProviders(<VerificationTool />);
+
+    await screen.findByText(/Loading the live registry/i);
+    for (const u of MOCK_VERIFIED) {
+      expect(screen.queryByText(u.display_name)).toBeNull();
+    }
+    settle({ data: { users: [], count: 0 } });
+    await screen.findByText(/Live from/i);
+  });
+
+  it('renders an empty live registry rather than the fixtures', async () => {
+    client.get.mockResolvedValue({ data: { users: [], count: 0 } });
+    renderWithProviders(<VerificationTool />);
+
+    await screen.findByText(/Live from/i);
+    expect(screen.queryByText(/Seeded sample/i)).toBeNull();
+    expect(screen.getByText('No verified accounts.')).toBeTruthy();
+    for (const u of MOCK_VERIFIED) {
+      expect(screen.queryByText(u.display_name)).toBeNull();
+    }
+  });
+
+  it('falls back to the sample only when the endpoint is unreachable', async () => {
+    client.get.mockRejectedValue(new Error('offline'));
+    renderWithProviders(<VerificationTool />);
+
+    // Wait for the fixture row, not the banner: the banner is not the signal
+    // that the query has settled.
+    expect(await screen.findByText(MOCK_VERIFIED[0].display_name)).toBeTruthy();
+    expect(screen.getByText(/Seeded sample/i)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Follow-up to the #533 merge, prompted by tnats/listgem-platform#536 clearing the last fixtures from `pitch_lists`.

## Why

The concierge pages deliberately diverge from the repo's sample-fallback convention:

| Page | Rule |
|---|---|
| `OutreachBoardPage`, `VerificationTool` | `usingSample = !live` — an empty array is **live** |
| `ErQueuePage`, `LabelingPage` | `usingSample = !live \|\| live.length === 0` — empty is **sample** |

On a metrics dashboard the older rule is a convenience. On the board that answers *who do we contact next*, it would put seven invented people with `example.*` contacts in front of staff at the moment prod legitimately has none; on the verification registry it would show three fictional accounts as holding a real badge. That divergence was undefended and looked like an inconsistency someone would tidy up. Now pinned by tests on both pages.

## The bug the tests found

`usingSample` was true on the *first* render, before the query settled — so both pages flashed the complete fixture set while the request was in flight, then swapped to live data. Exactly the failure the divergence exists to prevent, just briefer. Both now gate on `isLoading` and show a neutral loading banner instead.

Tests cover both states per page: in-flight shows no fixture name, and settled-empty shows an empty live board rather than the sample.

89 tests, typecheck, lint, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)