### PR TITLE
Drive the type picker from GET /types (answers from #533)

### DIFF
--- a/docs/admin-plan-concierge-verification.md
+++ b/docs/admin-plan-concierge-verification.md
@@ -1,0 +1,111 @@
+# Admin plan — Concierge Pitch Lists (#434) + User Verification (#435)
+
+Scoping for the next admin build cycle. Source issues in `tnats/listgem-platform`:
+**#434** (Concierge Pitch Lists) and **#435** (identity-authenticity verification), a linked
+"concierge acquisition + trust" pair aimed at the cold-start problem.
+
+> **How this differs from the 2026-07 cycle.** That cycle was mostly *read-only metrics endpoints +
+> admin render* — small backend, small admin. This one is **backend-heavy**: new staging tables, a
+> provisioning transaction, invite/preview tokens, and a verification model. The admin portal is the
+> *operator surface* on top of that — the smaller slice. Critical path is backend, and it is gated
+> upstream by **#433**. Expect multi-week, not multi-day.
+
+---
+
+## Dependency graph (read this first)
+
+```
+#433 Import a List  ──(parser + ER/KG resolve)──►  #434 build step   [#433 is OPEN/unbuilt — the gate]
+#338 Publish-promo  ──(CLOSED)──►                  target self-publishes after provisioning (not admin)
+#434 Concierge      ──(grant verified at provision)──►  #435 Phase 1  [near-dependency; ship together]
+/moderation (exists) ──(impersonation reports/takedown)──►  #435
+#183 curator weighting  ──  DECOUPLED (verification is display-only, never ranking)
+```
+
+**Consequences:**
+- The #434 **build UI** (paste/URL → resolve) cannot function until **#433's parser/resolve exists**.
+  Everything else in #434 (intake, outreach board, tokens, provisioning) does *not* depend on #433 and
+  can proceed in parallel.
+- **#435 Phase 1 ships with #434** — the pitch handoff grants `verified (method=concierge)`. Build them
+  as one cycle.
+- The **accept/provision path is backend + signup (main frontend)**, not admin — the admin only *builds
+  the draft and generates the invite*. Keep that boundary clear.
+
+---
+
+## Recommended sequencing
+
+1. **Confirm/land #433's parser + ER/KG resolve** (upstream, likely its own effort). Until then, #434's
+   build step is stubbed.
+2. **Backend, in parallel:** #434 staging tables + admin API + provisioning + tokens; #435 verification
+   model + admin verify API. (Both already have detailed "Backend design" sections in-issue — the backend
+   team can build from those; see "Backend asks" below for what admin specifically needs exposed.)
+3. **Admin UI, as each backend piece lands:** intake → outreach board → build → tokens; verify/unverify
+   tool + provisioning hook + impersonation queue.
+4. **#435 Phase 2 (self-serve cross-link)** — fast-follow, mostly main-frontend + a backend checker;
+   minimal admin role (review claims).
+
+---
+
+## Admin work items
+
+Effort: S ~½ day · M ~1–2 days · L ~3–5 days · XL > 1 week. All need backend unless noted.
+
+### #434 Concierge Pitch Lists — a new `/pitch` concierge surface
+
+| # | Item | Backend dependency | Effort |
+|---|------|--------------------|--------|
+| P1 | **Target intake** — form (name/org/contact/source URL) → create pitch target | `pitch_lists` CRUD (admin-gated) | S |
+| P2 | **Outreach board** — kanban by status (identified/built/pitched/accepted/declined/archived) + contact + notes | outreach-board query + status transitions | M |
+| P3 | **Build UI** — paste text / URL → parse → ER/KG resolve → review/edit items + type/category (reuse #433 dialogs) | build endpoint reusing **#433** (the gate) + `pitch_list_items` | L |
+| P4 | **Preview + invite links** — generate tokenized read-only preview + draft-scoped invite link | token endpoints (preview_token, invite_token) | S |
+| P5 | **Archive / re-pitch / takedown** — takedown archives draft + **purges contact info** (data hygiene) | status transitions + purge | S |
+
+- **Boundary note:** invite → signup → auto-provision is backend + main-frontend signup, not admin. Admin
+  ends at "generate invite link." Surface provisioned/declined status on the board (read-only).
+- **Build-now (no backend):** P2 (outreach board) and P1 (intake) UIs can be prototyped against a seeded
+  sample (the admin app's standard live-or-mock fallback pattern), ready to wire when the API lands.
+
+### #435 User Verification — admin verify tooling (Phase 1 ships with #434)
+
+| # | Item | Backend dependency | Effort |
+|---|------|--------------------|--------|
+| V1 | **Verify / unverify tool** — set `verified_type` + `verified_method` + evidence note; unverify with reason; full audit trail | user verification fields + admin verify/unverify API | M |
+| V2 | **Provisioning hook** — offer "grant verified (concierge)" in the #434 accept/handoff | provisioning grants verified | S (rides on #434) |
+| V3 | **Impersonation review queue** — reuse existing `/moderation` infra for identity disputes + takedown | report + takedown (mostly exists) | S |
+| V4 | **Phase 2 (fast-follow)** — review self-serve `rel=me`/domain claims | `verification_claims` + checker (mostly main-FE) | S (admin part) |
+
+- **Guardrails baked into the issue (respect them):** never self-asserted; revocation with reason +
+  audit; display-only (**zero** ranking effect); no paid tiers, no expertise tiers.
+
+---
+
+## Backend asks (what admin needs exposed)
+
+Both issues already carry detailed "Backend design" sections, so the backend team can largely build from
+#434/#435 directly. The admin-specific exposures to confirm as a hand-off (mirroring #476):
+
+- **#434:** admin-gated CRUD on `pitch_lists`/`pitch_list_items`; a build endpoint (reuse #433 parse +
+  resolve) returning per-item `resolution_status`; token generation (preview + invite); status-transition
+  endpoints; the outreach-board query (list by status + contact/notes).
+- **#435:** `verified` object on user/curator responses; admin verify/unverify endpoints with audit;
+  the provisioning-time grant; impersonation-report surfacing via `/moderation`.
+- **Gate:** #433's parser/resolve must be callable server-side for #434-P3.
+
+**Open product questions to resolve before build** (from the issues — not admin's call alone): invite
+token capability-vs-email-match + expiry; published-list provenance credit; re-pitch-from-archive in v1?;
+per-staff vs shared pitch workspace; org-verification authorization; Phase-2 proof strictness.
+
+---
+
+## What the admin team can start now
+- **Prototype the two highest-value UI shells against seeded samples** — the #434 **outreach board**
+  (P2) and the #435 **verify/unverify tool** (V1) — using the existing live-or-mock fallback pattern, so
+  they're ready to wire the moment the APIs land. Neither needs backend to design/review.
+- **Not** the #434 build UI (P3) — it's gated on #433; don't start it until the parser is real.
+
+## Recommendation
+Treat #434 + #435-Phase-1 as **one cycle**, backend-led. Admin starts by prototyping the outreach board
+(P2) and verify tool (V1) against mocks now; wires them + the token/intake flows as the backend lands;
+the #433-gated build UI (P3) comes last. Phase 2 verification is a fast-follow. This is a materially
+larger effort than 2026-07 — plan it as a mini-epic, not a backlog sweep.

--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -63,24 +63,40 @@ All three inferences were wrong. Verified live and corrected:
 | `POST /resolve/batch` body | `{ items: [{ position, raw_text }] }` | `{ candidates: [{ type, title }] }` |
 | Verdict vocabulary | `resolved` / `ambiguous` | `found_existing`, `no_match` (mapped in `SERVER_STATUS`) |
 | Alternates | `candidates` / `matches` | **`suggestions`** |
-| `thing_type` source | `/admin/type-rules` | Not a type vocabulary — 355 crawler URL-pattern rules on `detected_type`, still carrying retired types (Gym, Cafe, Bar, Store). The select uses a curated list |
+| `thing_type` source | `/admin/type-rules` | Not a type vocabulary — 355 crawler URL-pattern rules on `detected_type`. The canonical list is **`GET /types`** |
 
 Two consequences worth keeping in mind:
 
-- **Every resolve needs a type.** `/imports/parse` returns `inferred_type`, usually `null`, so the builder
-  falls back to the pitch's own `thing_type`. A pitch whose list mixes types will resolve the odd ones out
-  under the wrong type — a per-row type override is the obvious follow-up if that shows up in practice.
-- **`suggestions` must never be auto-adopted.** A `no_match` frequently ships exactly one suggestion.
-  Promoting it would turn "we could not match this" into a silent, wrong link, so a lone candidate is only
-  adopted when the server returned no verdict of its own. Pinned by a test.
+- **Every resolve needs a type**, and the builder uses the pitch's own `thing_type`. That is correct rather
+  than a compromise: `lists.thing_type` is NOT NULL and single-valued, and the trigger
+  `validate_thing_type_match` (migration 067) enforces upward-only matching, so a genuinely mixed list
+  cannot exist. Two pitches, not one. `inferred_type` from `/imports/parse` is the caller's hint echoed
+  back — the parser never guesses per item — so it is only non-null for rows rebuilt from saved items,
+  where it carries `thing_type_actual`.
+- **`suggestions` must never be auto-adopted.** A `no_match` frequently ships exactly one suggestion,
+  because the matcher is k-NN and the nearest thing to an unmatched title is usually one plausible-looking
+  neighbour. `status` is the verdict; `suggestions` never is. Promoting it would turn "we could not match
+  this" into a wrong link on a list we pitched to a real person. A lone candidate is adopted only when the
+  server returned no verdict of its own. Pinned by a test.
 
 Saved items are shaped differently again: no nested `thing`, with the resolved entity in `thing_metadata`
 (title/year) and the type in `thing_type_actual`, ordered by `position`. Reading a top-level `title` left
 every resolved row showing "—".
 
-**Open question for the backend:** `/resolve` has no URL path, so the builder's add-by-URL control was
-removed. If the web app's add-flow accepts URLs it must go through a different endpoint — worth asking
-before rebuilding that affordance.
+**Add-by-URL is deliberately absent.** `/resolve` is a text resolver with no URL path. The web app's
+add-by-URL uses `POST /ingestion/pre-flight`, which fetches and extracts the page — built for the
+interactive one-URL-at-a-time flow, rate-limited and Redis-cached for that shape. Doing it here would mean
+`pre-flight` → take the extracted title → `/resolve`, two calls per row. That's a feature, not wiring;
+the backend offered a single combined endpoint if staff hit a real need for it.
+(`GET /things/by-url` is *not* the answer — it's an exact lookup against Things already in the registry.)
+
+**The type picker** reads `GET /types` (96 entries, public, no auth) — the same vocabulary
+`isValidThingType()` validates against, so it cannot offer a type `POST /pitches` rejects. Two wrinkles:
+the endpoint still returns the four retired types (`Cafe`, `Gym`, `Bar`, `Store`) with `supported: true`
+and counts of 1–2, so they are filtered via `src/taxonomy.js` — offering them would manufacture the drift
+the Taxonomy Health panel (#456) exists to detect. And it excludes five abstract parents that
+`isValidThingType()` accepts, which is divergence in the safe direction. Options sort by `count`, deepest
+registry first. There is no free-text escape hatch: with a live vocabulary, free text can only 400.
 
 `/imports/parse` failures fall back to splitting pasted text one item per line, so a build can still
 proceed by hand.

--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -458,6 +458,19 @@ export function useResolveBatch() {
   });
 }
 
+// Canonical registry vocabulary — 96 types, public, no auth. This is what
+// isValidThingType() validates against, so a picker driven from it cannot offer
+// a type POST /pitches rejects. NOT /admin/type-rules, which is crawler
+// URL-pattern detection keyed on `detected_type`.
+export function useThingTypes() {
+  return useQuery({
+    queryKey: ['types'],
+    queryFn: () => client.get('/types').then(r => r.data),
+    staleTime: 300_000,
+    retry: false,
+  });
+}
+
 // --- Verification (#435) ---
 export function useVerifiedUsers({ type = '', limit = 50, offset = 0 } = {}) {
   return useQuery({

--- a/src/pages/concierge/IntakeModal.jsx
+++ b/src/pages/concierge/IntakeModal.jsx
@@ -1,11 +1,31 @@
 import { useState } from 'react';
 import Modal from '../../components/Modal';
 import { Button, Field, Select, TextArea, TextInput } from '../../components/Form';
-import { usePitchMutations } from '../../api/hooks';
+import { usePitchMutations, useThingTypes } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
-import { THING_TYPES, hasErrors, intakeErrors } from './pitchRules';
+import { RETIRED_THING_TYPES } from '../../taxonomy';
+import { FALLBACK_THING_TYPES, hasErrors, intakeErrors } from './pitchRules';
 
-const OTHER = '__other__';
+/**
+ * Options from the canonical vocabulary, retired types removed, deepest first —
+ * `count` is registry depth, which is a fair proxy for how well a type will
+ * actually resolve in the builder.
+ */
+function typeOptions(live) {
+  const usable = (live || []).filter(t => t?.type && !RETIRED_THING_TYPES.includes(t.type));
+  if (usable.length === 0) {
+    return { options: FALLBACK_THING_TYPES.map(t => ({ value: t, label: t })), offline: true };
+  }
+  const options = [...usable]
+    .sort((a, b) => (b.count || 0) - (a.count || 0))
+    .map(t => ({
+      value: t.type,
+      label: `${t.icon ? `${t.icon} ` : ''}${t.display_name || t.type}${
+        t.count ? ` · ${t.count.toLocaleString()}` : ''
+      }`,
+    }));
+  return { options, offline: false };
+}
 
 const EMPTY = {
   target_name: '',
@@ -23,10 +43,11 @@ const EMPTY = {
 
 export default function IntakeModal({ open, onClose, onCreated }) {
   const [form, setForm] = useState(EMPTY);
-  const [typeChoice, setTypeChoice] = useState('');
   const [submitted, setSubmitted] = useState(false);
   const [apiError, setApiError] = useState(null);
   const { create } = usePitchMutations();
+  const { data: typesData } = useThingTypes();
+  const { options: typeOpts, offline: typesOffline } = typeOptions(typesData?.types);
 
   const errors = intakeErrors(form);
   const show = key => (submitted ? errors[key] : undefined);
@@ -34,7 +55,6 @@ export default function IntakeModal({ open, onClose, onCreated }) {
 
   function close() {
     setForm(EMPTY);
-    setTypeChoice('');
     setSubmitted(false);
     setApiError(null);
     onClose?.();
@@ -136,23 +156,19 @@ export default function IntakeModal({ open, onClose, onCreated }) {
 
       <div className="grid grid-cols-2 gap-x-4">
         <Field label="Thing type" required error={show('thing_type')} htmlFor="thing_type">
+          {/* No free-text escape hatch: with the live vocabulary, anything not on
+              this list can only produce a 400. */}
           <Select
             id="thing_type"
-            value={typeChoice}
+            value={form.thing_type}
             placeholder="Select a type…"
-            options={[...THING_TYPES.map(t => ({ value: t, label: t })), { value: OTHER, label: 'Other…' }]}
-            onChange={e => {
-              setTypeChoice(e.target.value);
-              set('thing_type', e.target.value === OTHER ? '' : e.target.value);
-            }}
+            options={typeOpts}
+            onChange={e => set('thing_type', e.target.value)}
           />
-          {typeChoice === OTHER && (
-            <TextInput
-              className="mt-2"
-              value={form.thing_type}
-              onChange={e => set('thing_type', e.target.value)}
-              placeholder="Exact registry type, e.g. Movie"
-            />
+          {typesOffline && (
+            <p className="mt-1 text-xs text-amber-700">
+              <code>/types</code> unreachable — showing a short offline list.
+            </p>
           )}
         </Field>
         <Field label="Category" htmlFor="category">

--- a/src/pages/concierge/IntakeModal.test.jsx
+++ b/src/pages/concierge/IntakeModal.test.jsx
@@ -1,0 +1,71 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import client from '../../api/client';
+import IntakeModal from './IntakeModal';
+import { RETIRED_THING_TYPES } from '../../taxonomy';
+
+vi.mock('../../api/client', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+// Trimmed from the real GET /types, 2026-08-12. Note Cafe: the canonical
+// vocabulary still ships the retired types with supported: true.
+const TYPES = {
+  types: [
+    { type: 'Movie', display_name: 'Movie', icon: '🎬', parent_type: 'CreativeWork', supported: true, count: 11943 },
+    { type: 'Restaurant', display_name: 'Restaurant', icon: '🍽️', parent_type: 'Place', supported: true, count: 1429 },
+    { type: 'Beach', display_name: 'Beach', icon: '🏖️', parent_type: 'Place', supported: true, count: 0 },
+    { type: 'Cafe', display_name: 'Cafe', icon: '☕', parent_type: 'Place', supported: true, count: 2 },
+  ],
+};
+
+const optionText = () => [...document.querySelectorAll('#thing_type option')].map(o => o.textContent);
+
+describe('intake type picker', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+  });
+
+  it('offers the canonical vocabulary, deepest registry first', async () => {
+    client.get.mockResolvedValue({ data: TYPES });
+    renderWithProviders(<IntakeModal open onClose={() => {}} />);
+
+    await screen.findByText(/🎬 Movie/);
+    // count is registry depth — a fair proxy for how well a type will resolve.
+    expect(optionText().slice(1)).toEqual([
+      '🎬 Movie · 11,943',
+      '🍽️ Restaurant · 1,429',
+      '🏖️ Beach',
+    ]);
+  });
+
+  it('never offers a retired type, even though /types still returns them', async () => {
+    // Creating rows under a retired type manufactures the drift the Taxonomy
+    // Health panel (#456) exists to detect.
+    client.get.mockResolvedValue({ data: TYPES });
+    renderWithProviders(<IntakeModal open onClose={() => {}} />);
+
+    await screen.findByText(/🎬 Movie/);
+    for (const retired of RETIRED_THING_TYPES) {
+      expect(optionText().some(t => t.includes(retired))).toBe(false);
+    }
+  });
+
+  it('has no free-text escape hatch — it could only ever produce a 400', async () => {
+    client.get.mockResolvedValue({ data: TYPES });
+    renderWithProviders(<IntakeModal open onClose={() => {}} />);
+
+    await screen.findByText(/🎬 Movie/);
+    expect(optionText().some(t => /other/i.test(t))).toBe(false);
+    expect(screen.queryByPlaceholderText(/Exact registry type/i)).toBeNull();
+  });
+
+  it('falls back to the offline list when /types is unreachable', async () => {
+    client.get.mockRejectedValue(new Error('offline'));
+    renderWithProviders(<IntakeModal open onClose={() => {}} />);
+
+    await screen.findByText(/unreachable/i);
+    expect(optionText()).toContain('Movie');
+  });
+});

--- a/src/pages/concierge/pitchRules.ts
+++ b/src/pages/concierge/pitchRules.ts
@@ -240,15 +240,12 @@ export function isExpired(expiresAt?: string | null, now: number = Date.now()): 
 }
 
 /**
- * Registry types offered by the intake select.
- *
- * Curated on purpose. /admin/type-rules is NOT a type vocabulary — it is 355
- * crawler URL-pattern rules keyed on `detected_type`, and it still carries
- * retired types (Gym, Cafe, Bar, Store). Driving the select from it would offer
- * types the registry no longer accepts. The "Other…" escape hatch covers
- * anything missing here; POST /pitches 400s on a type it doesn't know.
+ * Offline fallback for the intake select. The live vocabulary is `GET /types`
+ * (96 entries, public, no auth) — see `useThingTypes`. This list only appears
+ * when that endpoint is unreachable, which is also when POST /pitches is
+ * unreachable, so it exists to keep the form demoable rather than usable.
  */
-export const THING_TYPES: string[] = [
+export const FALLBACK_THING_TYPES: string[] = [
   'Movie',
   'TVSeries',
   'Book',

--- a/src/pages/pipeline/PipelinePage.jsx
+++ b/src/pages/pipeline/PipelinePage.jsx
@@ -4,9 +4,10 @@ import StatCard from '../../components/StatCard';
 import StatusBadge from '../../components/StatusBadge';
 import { useCrawlAnalytics, useRegistrySearch, useTypeRules, useQueueStats, useQualityByType } from '../../api/hooks';
 import client from '../../api/client';
+import { RETIRED_THING_TYPES } from '../../taxonomy';
 
 // Commodity types retired by #456 ("curation, not directory") — should be empty.
-const RETIRED_TYPES = ['Cafe', 'Gym', 'Bar', 'Store'];
+const RETIRED_TYPES = RETIRED_THING_TYPES;
 
 export default function PipelinePage() {
   const { data: crawls } = useCrawlAnalytics();

--- a/src/taxonomy.js
+++ b/src/taxonomy.js
@@ -1,0 +1,11 @@
+// Registry taxonomy facts shared across admin surfaces.
+
+/**
+ * Types the taxonomy retired but that still exist in the registry — and, notably,
+ * are still returned by `GET /types` with `supported: true` and counts of 1–2.
+ *
+ * The Pipeline page's Taxonomy Health panel (#456) tracks sightings of these as
+ * drift, so no admin picker may offer them: creating new rows under a retired
+ * type manufactures the exact signal that panel exists to detect.
+ */
+export const RETIRED_THING_TYPES = ['Cafe', 'Gym', 'Bar', 'Store'];


### PR DESCRIPTION
Actions the one actionable item from the backend's answers on tnats/listgem-platform#533.

## GET /types replaces the hardcoded list

96 entries, public, no auth, and the same vocabulary `isValidThingType()` validates against — so the picker can no longer offer a type `POST /pitches` rejects. Options carry `icon` and `display_name`, and sort by `count` (registry depth), which is a fair proxy for how well a type will actually resolve in the builder.

## One wrinkle, found by checking the endpoint rather than the description

**The four retired types are still in `GET /types`**, `supported: true`:

```
Cafe count=2   Gym count=1   Bar count=1   Store count=1
```

Those are precisely the sightings the Pipeline page's Taxonomy Health panel (#456) tracks as drift. An unfiltered picker would let staff manufacture the signal another admin page exists to detect. Filtered — and since `PipelinePage` already had the list inline, it now lives in `src/taxonomy.js` with both reading from it.

## Also

- **"Other…" removed.** With a live vocabulary, free text can only produce a 400.
- **Offline fallback kept**, but honest about itself: it only appears when `/types` is unreachable, which is also when `POST /pitches` is unreachable, so it keeps the form demoable rather than usable — and says so in the UI.
- **Docs** carry the rest of the backend's answers: add-by-URL would be `pre-flight` → `/resolve` (a feature, not wiring), and the mixed-type list I worried about isn't representable — `lists.thing_type` is NOT NULL and single-valued with `validate_thing_type_match` enforcing upward-only matching, so the pitch's `thing_type` is the right fallback rather than a compromise.

93 tests, typecheck, lint, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)