### PR TITLE
Fix Modal stealing focus back on every render

### DIFF
--- a/src/components/Modal.jsx
+++ b/src/components/Modal.jsx
@@ -11,20 +11,34 @@ const SIZES = { sm: 'max-w-sm', md: 'max-w-lg', lg: 'max-w-2xl', xl: 'max-w-4xl'
 export default function Modal({ open, title, description, onClose, children, footer, size = 'md' }) {
   const panelRef = useRef(null);
 
+  // Keep the latest onClose in a ref so the listener below binds once. Callers
+  // pass an inline arrow, which changes identity on every render.
+  const onCloseRef = useRef(onClose);
+  useEffect(() => {
+    onCloseRef.current = onClose;
+  });
+
   useEffect(() => {
     if (!open) return undefined;
     function onKey(e) {
-      if (e.key === 'Escape') onClose?.();
+      if (e.key === 'Escape') onCloseRef.current?.();
     }
     window.addEventListener('keydown', onKey);
     const prevOverflow = document.body.style.overflow;
     document.body.style.overflow = 'hidden';
-    panelRef.current?.querySelector('input, textarea, select, button')?.focus();
     return () => {
       window.removeEventListener('keydown', onKey);
       document.body.style.overflow = prevOverflow;
     };
-  }, [open, onClose]);
+  }, [open]);
+
+  // Focus the first control ONCE per opening — never on subsequent renders.
+  // Sharing an effect with the listener above (and keying it on `onClose`) meant
+  // this re-ran on every keystroke and yanked the caret back to the first field.
+  useEffect(() => {
+    if (!open) return;
+    panelRef.current?.querySelector('input, textarea, select, button')?.focus();
+  }, [open]);
 
   if (!open) return null;
 

--- a/src/components/Modal.test.jsx
+++ b/src/components/Modal.test.jsx
@@ -1,0 +1,49 @@
+import { useState } from 'react';
+import { describe, expect, it } from 'vitest';
+import { fireEvent, render, screen } from '@testing-library/react';
+import Modal from './Modal';
+
+/**
+ * Mirrors how every dialog in the portal uses Modal: local state, and an inline
+ * arrow for onClose that changes identity on each render. That combination is
+ * what made the focus effect re-run on every keystroke.
+ */
+function Host() {
+  const [first, setFirst] = useState('');
+  const [second, setSecond] = useState('');
+  return (
+    <Modal open title="Test dialog" onClose={() => {}}>
+      <input aria-label="first" value={first} onChange={e => setFirst(e.target.value)} />
+      <input aria-label="second" value={second} onChange={e => setSecond(e.target.value)} />
+    </Modal>
+  );
+}
+
+describe('Modal focus', () => {
+  it('focuses the first control when it opens', () => {
+    render(<Host />);
+    expect(document.activeElement).toBe(screen.getByLabelText('first'));
+  });
+
+  it('does not steal focus back on re-render', () => {
+    render(<Host />);
+    const second = screen.getByLabelText('second');
+    second.focus();
+    fireEvent.change(second, { target: { value: 'typing here' } });
+
+    // Regression: the focus effect was keyed on [open, onClose], so an inline
+    // onClose re-ran it every render and yanked the caret to the first field.
+    expect(document.activeElement).toBe(second);
+  });
+
+  it('keeps focus across several keystrokes', () => {
+    render(<Host />);
+    const second = screen.getByLabelText('second');
+    second.focus();
+    for (const value of ['a', 'ab', 'abc']) {
+      fireEvent.change(second, { target: { value } });
+      expect(document.activeElement).toBe(second);
+    }
+    expect(second.value).toBe('abc');
+  });
+});

--- a/src/pages/concierge/IntakeModal.test.jsx
+++ b/src/pages/concierge/IntakeModal.test.jsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { screen } from '@testing-library/react';
+import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
 import client from '../../api/client';
 import IntakeModal from './IntakeModal';
@@ -67,5 +67,24 @@ describe('intake type picker', () => {
 
     await screen.findByText(/unreachable/i);
     expect(optionText()).toContain('Movie');
+  });
+});
+
+describe('intake form focus', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+    client.get.mockResolvedValue({ data: TYPES });
+  });
+
+  it('leaves the caret where the operator put it', async () => {
+    renderWithProviders(<IntakeModal open onClose={() => {}} />);
+    await screen.findByText(/🎬 Movie/);
+
+    const title = screen.getByLabelText(/Proposed title/i);
+    title.focus();
+    fireEvent.change(title, { target: { value: 'Essential Nordic Noir' } });
+
+    expect(document.activeElement).toBe(title);
+    expect(screen.getByLabelText(/Target name/i).value).toBe('');
   });
 });


### PR DESCRIPTION
**Reported:** typing in the new-target form's *Proposed Title* snaps the caret back to *Target Name* each keystroke.

**Cause is in `Modal`, not the form** — so every dialog in the portal had it: intake, confirm-identity, takedown, edit-details, verify/unverify.

The Escape listener, scroll lock and initial focus shared one effect keyed on `[open, onClose]`. Every caller passes an inline arrow for `onClose`, so its identity changes each render → the effect re-ran each render → each run called `focus()` on the first control in the panel. Typing re-renders the dialog, so the caret bounced to field one on every character.

Split into two effects: listener + scroll lock on `[open]` with `onClose` read from a ref; focus on `[open]` alone, so it fires once per opening.

## Why the tests missed it

Every existing test drives inputs with `fireEvent.change`, which sets a value without caring where focus is. Same shape of blind spot as a green run that never checks its own cleanup — the assertion never touched the thing that broke.

New tests assert `document.activeElement` across renders, at both levels: `Modal` (root cause, with a host component that mirrors how every dialog uses it) and `IntakeModal` (as reported). **Verified they fail with the fix reverted:**

```
does not steal focus back on re-render      ×
keeps focus across several keystrokes       ×
leaves the caret where the operator put it  ×
```

97 tests, typecheck, lint green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)