### PR TITLE
Assignee picker from portal staff; group EditDetailsModal

### DIFF
--- a/src/pages/concierge/AssigneeSelect.jsx
+++ b/src/pages/concierge/AssigneeSelect.jsx
@@ -1,0 +1,31 @@
+import { Select } from '../../components/Form';
+import { useAdminUsers } from '../../api/hooks';
+
+/**
+ * Assignee picker, sourced from the portal's own staff accounts.
+ *
+ * `assigned_to` is free text server-side and the board filters it with an exact
+ * string match (`WHERE assigned_to = $n`), so a typo returns an empty board with
+ * no error — which reads as "nothing assigned" rather than "you typed it
+ * differently". A closed list of real accounts removes the failure mode instead
+ * of documenting it.
+ *
+ * Values already on existing pitches stay selectable via `extra`, so nothing
+ * typed before this existed becomes unreachable.
+ */
+export default function AssigneeSelect({ id, value, onChange, extra = [], placeholder = 'Unassigned' }) {
+  const { data } = useAdminUsers({ limit: 200 });
+
+  const staff = (data?.users || [])
+    .filter(u => u.is_admin || u.is_moderator)
+    .map(u => u.email)
+    .filter(Boolean);
+
+  const options = [...new Set([...staff, ...extra.filter(Boolean), value].filter(Boolean))]
+    .sort()
+    .map(v => ({ value: v, label: v }));
+
+  return (
+    <Select id={id} value={value || ''} onChange={onChange} placeholder={placeholder} options={options} />
+  );
+}

--- a/src/pages/concierge/EditDetailsModal.jsx
+++ b/src/pages/concierge/EditDetailsModal.jsx
@@ -3,21 +3,40 @@ import Modal from '../../components/Modal';
 import { Button, Field, TextArea, TextInput } from '../../components/Form';
 import { usePitchMutations } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
+import AssigneeSelect from './AssigneeSelect';
 
 // PATCH /pitches/:id takes editable fields only — status and tokens have their
 // own endpoints and are deliberately absent here.
-const FIELDS = [
-  { key: 'target_name', label: 'Target name' },
+//
+// Grouped exactly as intake is, and for the same reason: the second group is
+// copied onto the target's list when they claim the draft, so those fields are
+// written for them. Editing them after a claim does nothing — the API freezes a
+// provisioned pitch — so this dialog is for the window before that.
+const INTERNAL = [
+  { key: 'target_name', label: 'Target name', hint: 'The person or organisation, not the list.' },
   { key: 'target_org', label: 'Organisation' },
   { key: 'target_contact', label: 'Contact', hint: 'Purged in full by takedown.' },
-  { key: 'source_url', label: 'Source URL' },
-  { key: 'source_attribution', label: 'Source attribution' },
-  { key: 'proposed_title', label: 'Proposed title' },
-  { key: 'proposed_description', label: 'Proposed description', multiline: true },
-  { key: 'category', label: 'Category' },
-  { key: 'assigned_to', label: 'Assigned to' },
   { key: 'notes', label: 'Notes', multiline: true },
 ];
+
+const INHERITED = [
+  { key: 'proposed_title', label: 'Proposed title', hint: "The list's name, as they'll see it." },
+  { key: 'proposed_description', label: 'Proposed description', multiline: true },
+  { key: 'category', label: 'Category', hint: 'Free text. Copied onto their list.' },
+  { key: 'source_url', label: 'Source URL', hint: "The exact page you're rebuilding." },
+  { key: 'source_attribution', label: 'Source attribution', hint: 'Credit line on their list.' },
+];
+
+const FIELDS = [...INTERNAL, ...INHERITED, { key: 'assigned_to', label: 'Assigned to' }];
+
+function Section({ title, note }) {
+  return (
+    <div className="mt-1 mb-3 border-b border-gray-100 pb-1.5">
+      <h4 className="text-xs font-semibold tracking-wide text-gray-700 uppercase">{title}</h4>
+      <p className="mt-0.5 text-xs text-gray-400">{note}</p>
+    </div>
+  );
+}
 
 export default function EditDetailsModal({ open, pitch, onClose, onSaved }) {
   const [form, setForm] = useState(() => Object.fromEntries(FIELDS.map(f => [f.key, pitch?.[f.key] ?? ''])));
@@ -31,6 +50,8 @@ export default function EditDetailsModal({ open, pitch, onClose, onSaved }) {
     setForm(Object.fromEntries(FIELDS.map(f => [f.key, pitch?.[f.key] ?? ''])));
   }
 
+  const set = (key, value) => setForm(s => ({ ...s, [key]: value }));
+
   async function submit() {
     setApiError(null);
     try {
@@ -42,6 +63,25 @@ export default function EditDetailsModal({ open, pitch, onClose, onSaved }) {
       setApiError(apiErrorMessage(err));
     }
   }
+
+  const renderField = f => (
+    <Field key={f.key} label={f.label} hint={f.hint} htmlFor={`edit_${f.key}`}>
+      {f.multiline ? (
+        <TextArea
+          id={`edit_${f.key}`}
+          rows={2}
+          value={form[f.key] || ''}
+          onChange={e => set(f.key, e.target.value)}
+        />
+      ) : (
+        <TextInput
+          id={`edit_${f.key}`}
+          value={form[f.key] || ''}
+          onChange={e => set(f.key, e.target.value)}
+        />
+      )}
+    </Field>
+  );
 
   return (
     <Modal
@@ -59,24 +99,22 @@ export default function EditDetailsModal({ open, pitch, onClose, onSaved }) {
       }
     >
       {apiError && <div className="mb-3 rounded bg-red-50 p-2 text-xs text-red-700">{apiError}</div>}
-      {FIELDS.map(f => (
-        <Field key={f.key} label={f.label} hint={f.hint} htmlFor={`edit_${f.key}`}>
-          {f.multiline ? (
-            <TextArea
-              id={`edit_${f.key}`}
-              rows={2}
-              value={form[f.key] || ''}
-              onChange={e => setForm(s => ({ ...s, [f.key]: e.target.value }))}
-            />
-          ) : (
-            <TextInput
-              id={`edit_${f.key}`}
-              value={form[f.key] || ''}
-              onChange={e => setForm(s => ({ ...s, [f.key]: e.target.value }))}
-            />
-          )}
-        </Field>
-      ))}
+
+      <Section title="Who you're pitching to" note="Internal. Never shown to the target." />
+      {INTERNAL.map(renderField)}
+      <Field label="Assigned to" hint="Who's chasing this one." htmlFor="edit_assigned_to">
+        <AssigneeSelect
+          id="edit_assigned_to"
+          value={form.assigned_to}
+          onChange={e => set('assigned_to', e.target.value)}
+        />
+      </Field>
+
+      <Section
+        title="The list they'll receive"
+        note="Copied into their account when they claim the draft — write it for them, not for us."
+      />
+      {INHERITED.map(renderField)}
     </Modal>
   );
 }

--- a/src/pages/concierge/IntakeModal.jsx
+++ b/src/pages/concierge/IntakeModal.jsx
@@ -4,6 +4,7 @@ import { Button, Field, Select, TextArea, TextInput } from '../../components/For
 import { usePitchMutations, useThingTypes } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
 import { RETIRED_THING_TYPES } from '../../taxonomy';
+import AssigneeSelect from './AssigneeSelect';
 import { FALLBACK_THING_TYPES, hasErrors, intakeErrors } from './pitchRules';
 
 /**
@@ -150,16 +151,11 @@ export default function IntakeModal({ open, onClose, onCreated }) {
       </Field>
 
       <div className="grid grid-cols-2 gap-x-4">
-        <Field
-          label="Assigned to"
-          hint="The board filter matches this exactly — use whatever form the team agreed."
-          htmlFor="assigned_to"
-        >
-          <TextInput
+        <Field label="Assigned to" hint="Who's chasing this one. Optional." htmlFor="assigned_to">
+          <AssigneeSelect
             id="assigned_to"
             value={form.assigned_to}
             onChange={e => set('assigned_to', e.target.value)}
-            placeholder="e.g. gtm@listgem.com"
           />
         </Field>
         <Field label="Notes" hint="Anything the next person needs to know." htmlFor="notes">

--- a/src/pages/concierge/IntakeModal.test.jsx
+++ b/src/pages/concierge/IntakeModal.test.jsx
@@ -88,3 +88,37 @@ describe('intake form focus', () => {
     expect(screen.getByLabelText(/Target name/i).value).toBe('');
   });
 });
+
+describe('assignee picker', () => {
+  const STAFF = {
+    users: [
+      { user_id: 'u1', email: 'gtm@listgem.com', username: 'gtm', is_admin: true, is_moderator: false },
+      { user_id: 'u2', email: 'mod@listgem.com', username: 'mod', is_admin: false, is_moderator: true },
+      { user_id: 'u3', email: 'someone@example.com', username: 'someone', is_admin: false, is_moderator: false },
+    ],
+    total: 3,
+  };
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.get.mockImplementation(url =>
+      url === '/types'
+        ? Promise.resolve({ data: TYPES })
+        : url === '/admin/users'
+          ? Promise.resolve({ data: STAFF })
+          : Promise.reject(new Error('not mocked')),
+    );
+  });
+
+  // assigned_to is free text server-side and the board filter matches it
+  // exactly, so a typo returns an empty board with no error. A closed list of
+  // real accounts removes the failure rather than documenting it.
+  it('offers portal staff only, never a free-text box', async () => {
+    renderWithProviders(<IntakeModal open onClose={() => {}} />);
+    await screen.findByText('gtm@listgem.com');
+
+    const options = [...document.querySelectorAll('#assigned_to option')].map(o => o.textContent);
+    expect(options).toEqual(['Unassigned', 'gtm@listgem.com', 'mod@listgem.com']);
+    expect(document.querySelector('input#assigned_to')).toBeNull();
+  });
+});

--- a/src/pages/concierge/OutreachBoardPage.jsx
+++ b/src/pages/concierge/OutreachBoardPage.jsx
@@ -1,12 +1,13 @@
 import { useState } from 'react';
 import { Link, useNavigate } from 'react-router-dom';
 import PageHeader from '../../components/PageHeader';
-import { Button, Select, TextInput } from '../../components/Form';
+import { Button, Select } from '../../components/Form';
 import { usePitches, usePitchMutations } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
 import { BOARD_COLUMNS, STATUS_LABEL, canRepitch } from './pitchRules';
 import { MOCK_PITCHES } from './mockPitches';
 import IntakeModal from './IntakeModal';
+import AssigneeSelect from './AssigneeSelect';
 
 function relativeDays(iso) {
   if (!iso) return null;
@@ -68,13 +69,14 @@ function PitchCard({ pitch, onRepitch, busy }) {
 export default function OutreachBoardPage() {
   const navigate = useNavigate();
   const [assignedTo, setAssignedTo] = useState('');
-  const [assignedInput, setAssignedInput] = useState('');
   const [statusFilter, setStatusFilter] = useState('');
   const [intakeOpen, setIntakeOpen] = useState(false);
   const [note, setNote] = useState(null);
   const [busyId, setBusyId] = useState(null);
 
-  const query = usePitches({ assignedTo });
+  // Unfiltered on purpose: filtering happens below, so the assignee list always
+  // offers every value present on the board rather than just the selected one.
+  const query = usePitches();
   const { setStatus } = usePitchMutations();
 
   // Don't paint the sample while the request is still in flight: for that beat
@@ -84,10 +86,9 @@ export default function OutreachBoardPage() {
   const usingSample = !query.isLoading && !live;
   const all = live || (usingSample ? MOCK_PITCHES : []);
   const pitches = all.filter(
-    p =>
-      (!statusFilter || p.status === statusFilter) &&
-      (!usingSample || !assignedTo || p.assigned_to === assignedTo),
+    p => (!statusFilter || p.status === statusFilter) && (!assignedTo || p.assigned_to === assignedTo),
   );
+  const knownAssignees = [...new Set(all.map(p => p.assigned_to).filter(Boolean))];
 
   const columns = BOARD_COLUMNS.map(col => ({
     ...col,
@@ -149,32 +150,19 @@ export default function OutreachBoardPage() {
           options={BOARD_COLUMNS.map(c => ({ value: c.status, label: STATUS_LABEL[c.status] }))}
           className="w-44"
         />
-        <form
-          className="flex items-center gap-2"
-          onSubmit={e => {
-            e.preventDefault();
-            setAssignedTo(assignedInput.trim());
-          }}
-        >
-          <TextInput
-            value={assignedInput}
-            onChange={e => setAssignedInput(e.target.value)}
-            placeholder="Filter by assignee…"
-            className="w-56"
+        <div className="w-56">
+          <AssigneeSelect
+            value={assignedTo}
+            onChange={e => setAssignedTo(e.target.value)}
+            extra={knownAssignees}
+            placeholder="All assignees"
           />
-          <Button type="submit">Apply</Button>
-          {assignedTo && (
-            <Button
-              variant="ghost"
-              onClick={() => {
-                setAssignedTo('');
-                setAssignedInput('');
-              }}
-            >
-              Clear
-            </Button>
-          )}
-        </form>
+        </div>
+        {assignedTo && (
+          <Button variant="ghost" onClick={() => setAssignedTo('')}>
+            Clear
+          </Button>
+        )}
         <span className="ml-auto text-xs text-gray-400 tabular-nums">
           {pitches.length} shown{query.isFetching ? ' · refreshing…' : ''}
         </span>

--- a/src/pages/concierge/OutreachBoardPage.test.jsx
+++ b/src/pages/concierge/OutreachBoardPage.test.jsx
@@ -1,5 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest';
-import { screen, waitFor } from '@testing-library/react';
+import { fireEvent, screen, waitFor } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
 import client from '../../api/client';
 import OutreachBoardPage from './OutreachBoardPage';
@@ -113,5 +113,42 @@ describe('outreach board — re-pitch gating (invariant 1)', () => {
     // The sample's declined target must not carry a re-pitch action either.
     const declinedCard = screen.getByText('Whitney Adeyemi-Cole').closest('div.rounded-lg');
     expect(declinedCard.textContent).not.toMatch(/re-pitch/i);
+  });
+});
+
+describe('outreach board — assignee filter', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+  });
+
+  // Previously a free-text box sent to the server as an exact match, so one
+  // typo returned an empty board with no error. Now a closed list, filtered
+  // client-side so every value on the board is always offered.
+  it('offers every assignee present on the board and filters to it', async () => {
+    client.get.mockImplementation(url =>
+      url === '/pitches'
+        ? Promise.resolve({
+            data: {
+              pitches: [
+                { ...QUIET, assigned_to: 'gtm@listgem.com' },
+                { ...DECLINED, assigned_to: 'ops@listgem.com' },
+              ],
+            },
+          })
+        : Promise.reject(new Error('not mocked')),
+    );
+    renderWithProviders(<OutreachBoardPage />);
+    await screen.findByText('Quiet Target');
+
+    const select = document.querySelectorAll('select')[1];
+    expect([...select.options].map(o => o.textContent)).toEqual([
+      'All assignees',
+      'gtm@listgem.com',
+      'ops@listgem.com',
+    ]);
+
+    fireEvent.change(select, { target: { value: 'ops@listgem.com' } });
+    expect(screen.queryByText('Quiet Target')).toBeNull();
+    expect(screen.getByText('Declined Target')).toBeTruthy();
   });
 });


### PR DESCRIPTION
## Assignees

`assigned_to` was free text, and the board filtered it with an exact string match — so `GTM` and `gtm@listgem.com` were different people, and a typo returned an empty board **with no error**, indistinguishable from "nothing is assigned". Documenting that was the wrong fix.

The people who can be assigned a pitch are the people who can log into the portal, so `AssigneeSelect` derives options from `/admin/users` (admins and moderators), valued on email. Nothing to agree, nothing to type, no typo possible. Values already on existing pitches stay selectable so nothing becomes unreachable.

**The board now filters client-side** instead of passing `assigned_to` to the API — same result at these volumes, and it keeps the option list complete. Filtering server-side would have narrowed the very list the filter is built from.

*Caveat:* this assumes assignees have portal logins. If a pitch ever needs assigning to someone without one, this needs a configured list instead.

## EditDetailsModal

Same two-group treatment as intake, for the same reason — half its fields are copied onto the target's list on claim, half are internal, and a flat list gave no way to tell which. Also notes that editing the inherited half after a claim does nothing, since the API freezes a provisioned pitch.

99 tests, typecheck, lint green. Playbook companion: listgem-website#98.

🤖 Generated with [Claude Code](https://claude.com/claude-code)