### PR TITLE
Grant and revoke staff roles from the portal (listgem-platform#542)

### DIFF
--- a/src/api/errors.js
+++ b/src/api/errors.js
@@ -9,10 +9,13 @@ export function apiErrorMessage(err) {
   const data = err?.response?.data;
   const status = err?.response?.status;
   const base = data?.error || data?.message || err?.message || 'Request failed';
+  // Several endpoints put the headline in `error` and the actionable part in
+  // `message` — the last-admin 409 being the one that matters most.
+  const detail = data?.error && data?.message && data.message !== data.error ? ` ${data.message}` : '';
   const allowed = Array.isArray(data?.allowed) && data.allowed.length
     ? ` Allowed from here: ${data.allowed.join(', ')}.`
     : '';
-  return `${status ? `${status} · ` : ''}${base}${allowed}`;
+  return `${status ? `${status} · ` : ''}${base}${detail}${allowed}`;
 }
 
 export function allowedFrom(err) {

--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -458,6 +458,21 @@ export function useResolveBatch() {
   });
 }
 
+// Grant/revoke staff roles (listgem-platform#542). Body takes is_admin and/or
+// is_moderator as booleans; omitted fields are left alone. 409 when the change
+// would remove the last admin — the portal is admin-only, so that would lock
+// everyone out.
+export function useUserRoles() {
+  const qc = useQueryClient();
+  return useMutation({
+    mutationFn: ({ userId, ...body }) => client.post(`/admin/users/${userId}/roles`, body).then(r => r.data),
+    onSuccess: () => {
+      qc.invalidateQueries({ queryKey: ['admin', 'users'] });
+      qc.invalidateQueries({ queryKey: ['verification'] });
+    },
+  });
+}
+
 // Canonical registry vocabulary — 96 types, public, no auth. This is what
 // isValidThingType() validates against, so a picker driven from it cannot offer
 // a type POST /pitches rejects. NOT /admin/type-rules, which is crawler

--- a/src/components/Form.jsx
+++ b/src/components/Form.jsx
@@ -64,6 +64,23 @@ export function Select({ options = [], placeholder, className = '', ...props }) 
   );
 }
 
+export function Checkbox({ label, hint, id, ...props }) {
+  return (
+    <label htmlFor={id} className="mb-2 flex cursor-pointer items-start gap-2">
+      <input
+        id={id}
+        type="checkbox"
+        className="mt-0.5 h-4 w-4 rounded border-gray-300 text-indigo-600 focus:ring-2 focus:ring-indigo-500"
+        {...props}
+      />
+      <span className="min-w-0">
+        <span className="block text-sm text-gray-800">{label}</span>
+        {hint && <span className="block text-xs text-gray-400">{hint}</span>}
+      </span>
+    </label>
+  );
+}
+
 export function Button({ variant = 'secondary', size = 'md', className = '', type = 'button', ...props }) {
   return (
     <button

--- a/src/pages/moderation/RolesModal.jsx
+++ b/src/pages/moderation/RolesModal.jsx
@@ -1,0 +1,121 @@
+import { useState } from 'react';
+import Modal from '../../components/Modal';
+import { Button, Checkbox, Field, TextArea } from '../../components/Form';
+import { useUserRoles } from '../../api/hooks';
+import { apiErrorMessage } from '../../api/errors';
+
+/**
+ * Grant or revoke staff roles (listgem-platform#542) — the replacement for
+ * running UPDATE against production by hand.
+ *
+ * Two things worth knowing, both enforced server-side and surfaced here:
+ *  - The last admin cannot be demoted (409). The portal is admin-only, so zero
+ *    admins locks everyone out with no recovery short of raw SQL.
+ *  - Demoting yourself succeeds while another admin remains, but your current
+ *    session keeps working: `is_admin` is a claim baked into the JWT at login,
+ *    so the change bites at next sign-in. The response's `self` flag is what
+ *    tells us to say so.
+ */
+export default function RolesModal({ open, user, onClose, onDone }) {
+  const [isAdmin, setIsAdmin] = useState(!!user?.is_admin);
+  const [isModerator, setIsModerator] = useState(!!user?.is_moderator);
+  const [reason, setReason] = useState('');
+  const [apiError, setApiError] = useState(null);
+  const roles = useUserRoles();
+
+  // Re-seed when a different row is opened.
+  const [seen, setSeen] = useState(user);
+  if (user !== seen) {
+    setSeen(user);
+    setIsAdmin(!!user?.is_admin);
+    setIsModerator(!!user?.is_moderator);
+    setReason('');
+    setApiError(null);
+  }
+
+  const label = user?.display_name || user?.username || user?.email;
+  const unchanged = !!user?.is_admin === isAdmin && !!user?.is_moderator === isModerator;
+  const losingOwnAdmin = user?.is_admin && !isAdmin;
+
+  function close() {
+    setReason('');
+    setApiError(null);
+    onClose?.();
+  }
+
+  async function submit() {
+    setApiError(null);
+    try {
+      const data = await roles.mutateAsync({
+        userId: user.user_id,
+        is_admin: isAdmin,
+        is_moderator: isModerator,
+        reason: reason.trim(),
+      });
+      close();
+      onDone?.(data);
+    } catch (err) {
+      setApiError(apiErrorMessage(err));
+    }
+  }
+
+  return (
+    <Modal
+      open={open}
+      onClose={close}
+      title="Staff roles"
+      description={label}
+      footer={
+        <>
+          <Button onClick={close}>Cancel</Button>
+          <Button
+            variant={losingOwnAdmin ? 'danger' : 'primary'}
+            onClick={submit}
+            disabled={roles.isPending || unchanged || !reason.trim()}
+          >
+            {roles.isPending ? 'Saving…' : 'Save roles'}
+          </Button>
+        </>
+      }
+    >
+      {apiError && <div className="mb-3 rounded bg-red-50 p-2 text-xs text-red-700">{apiError}</div>}
+
+      <Checkbox
+        id="role_is_admin"
+        label="Admin"
+        hint="Full portal access — moderation, verification, concierge, takedowns. The only role that can sign in."
+        checked={isAdmin}
+        onChange={e => setIsAdmin(e.target.checked)}
+      />
+      <Checkbox
+        id="role_is_moderator"
+        label="Moderator"
+        hint="Cannot sign into the portal today. Assignable on the concierge board."
+        checked={isModerator}
+        onChange={e => setIsModerator(e.target.checked)}
+      />
+
+      {losingOwnAdmin && (
+        <p className="mb-3 rounded bg-amber-50 p-2 text-xs text-amber-800">
+          Removing admin. If this is your own account you'll keep working until you sign out — the flag is read
+          into your session at login — and you won't be able to sign back in.
+        </p>
+      )}
+
+      <Field
+        label="Reason"
+        required
+        hint="Recorded in the audit trail, so an offboarding is answerable later."
+        htmlFor="role_reason"
+      >
+        <TextArea
+          id="role_reason"
+          rows={2}
+          value={reason}
+          onChange={e => setReason(e.target.value)}
+          placeholder="e.g. Onboarding Susan for concierge outreach."
+        />
+      </Field>
+    </Modal>
+  );
+}

--- a/src/pages/moderation/RolesModal.test.jsx
+++ b/src/pages/moderation/RolesModal.test.jsx
@@ -1,0 +1,82 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import client from '../../api/client';
+import RolesModal from './RolesModal';
+
+vi.mock('../../api/client', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+const USER = { user_id: 'u_susan', email: 'susan@listgem.com', username: 'susan', is_admin: false, is_moderator: false };
+
+const save = () => screen.getByRole('button', { name: /save roles/i });
+
+function open(user = USER, onDone = () => {}) {
+  renderWithProviders(<RolesModal open user={user} onClose={() => {}} onDone={onDone} />);
+}
+
+describe('roles modal', () => {
+  beforeEach(() => {
+    client.post.mockReset();
+  });
+
+  it('will not submit an unchanged form', () => {
+    open();
+    fireEvent.change(screen.getByLabelText(/Reason/i), { target: { value: 'no-op' } });
+    expect(save().disabled).toBe(true);
+  });
+
+  it('requires a reason — role changes are audited', () => {
+    open();
+    fireEvent.click(screen.getByLabelText(/Admin/i));
+    expect(save().disabled).toBe(true);
+    fireEvent.change(screen.getByLabelText(/Reason/i), { target: { value: 'Onboarding Susan' } });
+    expect(save().disabled).toBe(false);
+  });
+
+  it('sends both booleans and the reason', async () => {
+    client.post.mockResolvedValue({ data: { success: true, user: { ...USER, is_admin: true }, changed: ['is_admin false -> true'], self: false } });
+    const onDone = vi.fn();
+    open(USER, onDone);
+
+    fireEvent.click(screen.getByLabelText(/Admin/i));
+    fireEvent.change(screen.getByLabelText(/Reason/i), { target: { value: 'Onboarding Susan' } });
+    fireEvent.click(save());
+
+    await vi.waitFor(() => expect(onDone).toHaveBeenCalled());
+    expect(client.post).toHaveBeenCalledWith('/admin/users/u_susan/roles', {
+      is_admin: true,
+      is_moderator: false,
+      reason: 'Onboarding Susan',
+    });
+  });
+
+  it('surfaces the last-admin 409 with the part that says what to do', async () => {
+    // The endpoint puts the headline in `error` and the actionable half in
+    // `message`; showing only the headline would hide the fix.
+    client.post.mockRejectedValue({
+      response: {
+        status: 409,
+        data: {
+          error: 'Cannot remove the last admin',
+          message: 'The portal is admin-only, so this would lock everyone out. Grant another admin first.',
+        },
+      },
+    });
+    open({ ...USER, is_admin: true });
+
+    fireEvent.click(screen.getByLabelText(/Admin/i));
+    fireEvent.change(screen.getByLabelText(/Reason/i), { target: { value: 'offboarding' } });
+    fireEvent.click(save());
+
+    expect(await screen.findByText(/Cannot remove the last admin/i)).toBeTruthy();
+    expect(screen.getByText(/Grant another admin first/i)).toBeTruthy();
+  });
+
+  it('warns before you demote yourself out of the portal', () => {
+    open({ ...USER, is_admin: true });
+    fireEvent.click(screen.getByLabelText(/Admin/i));
+    expect(screen.getByText(/won't be able to sign back in/i)).toBeTruthy();
+  });
+});

--- a/src/pages/moderation/UserManagement.jsx
+++ b/src/pages/moderation/UserManagement.jsx
@@ -4,6 +4,7 @@ import VerifiedBadge from '../../components/VerifiedBadge';
 import { useAdminUsers, useVerifiedUsers } from '../../api/hooks';
 import client from '../../api/client';
 import VerifyModal from './VerifyModal';
+import RolesModal from './RolesModal';
 
 export default function UserManagement() {
   const [search, setSearch] = useState('');
@@ -23,6 +24,8 @@ export default function UserManagement() {
     (verifiedData?.users || verifiedData?.verified || []).map(u => [u.user_id, u.verified]),
   );
   const [verifyModal, setVerifyModal] = useState(null); // { mode, user }
+  const [rolesUser, setRolesUser] = useState(null);
+  const [roleNote, setRoleNote] = useState(null);
 
   // Action modal state
   const [modal, setModal] = useState(null); // { type, user }
@@ -92,6 +95,10 @@ export default function UserManagement() {
         </button>
       </form>
 
+      {roleNote && (
+        <div className="mb-3 rounded bg-green-50 p-2 text-xs text-green-700">{roleNote}</div>
+      )}
+
       {/* Users Table */}
       <div className="bg-white rounded-lg border border-gray-200 p-4">
         <div className="text-xs text-gray-400 mb-3">{total} users total</div>
@@ -144,6 +151,12 @@ export default function UserManagement() {
                   </td>
                   <td className="py-2 text-right">
                     <div className="flex gap-1 justify-end">
+                      <button
+                        onClick={() => setRolesUser(user)}
+                        className="px-2 py-0.5 text-xs bg-gray-50 text-gray-600 rounded hover:bg-gray-100"
+                      >
+                        Roles
+                      </button>
                       {(user.verified || verifiedById.get(user.user_id)) ? (
                         <button
                           onClick={() => setVerifyModal({ mode: 'unverify', user })}
@@ -260,6 +273,21 @@ export default function UserManagement() {
           </div>
         </div>
       )}
+
+      <RolesModal
+        open={!!rolesUser}
+        user={rolesUser}
+        onClose={() => setRolesUser(null)}
+        onDone={data => {
+          const who = data?.user?.email || data?.user?.username || 'User';
+          setRoleNote(
+            data?.changed?.length
+              ? `${who}: ${data.changed.join('; ')}.${data.self ? ' That was your own account — it takes effect at next sign-in.' : ''}`
+              : `${who}: no change.`,
+          );
+          refetch();
+        }}
+      />
 
       <VerifyModal
         open={!!verifyModal}


### PR DESCRIPTION
listgem-platform#543 shipped `POST /admin/users/:userId/roles`, so onboarding an operator no longer means running `UPDATE` against production by hand. This wires it into the Users tab, where the rows and their role badges already live.

A **Roles** action per row opens a dialog with the two flags and a reason. Both booleans are always sent — the checkboxes represent the desired end state — and the API leaves out what it isn't given, so nothing is clobbered either way.

`reason` is optional server-side (it defaults to *"Role updated via admin portal"*) but **required here**, matching warn/suspend/ban on the same screen. A privilege change nobody wrote a why for is the one you most want a why for later.

## Two failure modes handled explicitly

**The last admin can't be demoted (409).** The endpoint puts the headline in `error` and the actionable half in `message`, and `apiErrorMessage` was showing only the headline — so an operator would have read *"Cannot remove the last admin"* without *"Grant another admin first."* It now appends `message` when it differs, which improves every surface in the portal.

**Self-demotion is allowed but doesn't bite immediately.** `is_admin` is a claim baked into the JWT at login, so your current session keeps working and you simply can't sign back in. The dialog warns before you confirm; the response's `self` flag drives the note after.

Adds a `Checkbox` to the shared form primitives.

104 tests, typecheck, lint, build green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)