### PR TITLE
Builder: search the catalogue, not the duplicate-checker

### DIFF
--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -486,6 +486,18 @@ export function useThingTypes() {
   });
 }
 
+/**
+ * Federated search — registry + TMDB/Spotify/Google Books/Places/Yelp/Amazon.
+ * A GET, but modelled as a mutation because the builder searches on demand
+ * rather than as the operator types. 20/min per user.
+ */
+export function useSearchToAdd() {
+  return useMutation({
+    mutationFn: ({ query, type, limit = 10 }) =>
+      client.get('/search-to-add', { params: { query, type: type || undefined, limit } }).then(r => r.data),
+  });
+}
+
 // --- Verification (#435) ---
 export function useVerifiedUsers({ type = '', limit = 50, offset = 0 } = {}) {
   return useQuery({

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -1,15 +1,15 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import DataTable from '../../components/DataTable';
 import { Button, Field, TextArea, TextInput } from '../../components/Form';
-import { useImportParse, usePitchMutations, useResolve, useResolveBatch } from '../../api/hooks';
+import { useImportParse, usePitchMutations, useResolveBatch, useSearchToAdd } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
 import {
   ROW_STATUS,
   applyBatchResults,
   batchResults,
   chunkForBatch,
-  normalizeResolution,
   normalizeParsed,
+  normalizeSearchResults,
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
@@ -36,11 +36,22 @@ function Kbd({ children }) {
 }
 
 function CandidateRow({ candidate, chosen, onPick }) {
+  // A federated hit with no thing_id exists in TMDB/Spotify/Books but not in our
+  // registry. Shown rather than hidden — knowing it exists is what tells the
+  // operator to leave the row rather than keep hunting — but not attachable
+  // until listgem-platform#550.
+  const unavailable = !candidate.thing_id;
   return (
     <button
-      onClick={onPick}
+      onClick={unavailable ? undefined : onPick}
+      disabled={unavailable}
+      title={unavailable ? `Found in ${candidate.source || 'an external source'}, not yet in our registry` : undefined}
       className={`flex w-full items-baseline gap-2 rounded border px-2 py-1 text-left text-xs ${
-        chosen ? 'border-indigo-300 bg-indigo-50' : 'border-gray-200 hover:bg-gray-50'
+        unavailable
+          ? 'cursor-not-allowed border-dashed border-gray-200 text-gray-400'
+          : chosen
+            ? 'border-indigo-300 bg-indigo-50'
+            : 'border-gray-200 hover:bg-gray-50'
       }`}
     >
       <span className="min-w-0 flex-1 truncate text-gray-800">{candidate.title}</span>
@@ -50,6 +61,7 @@ function CandidateRow({ candidate, chosen, onPick }) {
       {candidate.score != null && (
         <span className="tabular-nums text-gray-400">{Number(candidate.score).toFixed(2)}</span>
       )}
+      {unavailable && <span className="shrink-0 text-[10px] uppercase tracking-wide">not in registry</span>}
     </button>
   );
 }
@@ -73,7 +85,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
 
   const parse = useImportParse();
   const resolveBatch = useResolveBatch();
-  const resolveOne = useResolve();
+  const searchToAdd = useSearchToAdd();
   const { saveItems } = usePitchMutations(pitchId);
 
   // Re-seed when the server's item set changes identity (detail query settles).
@@ -174,22 +186,28 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     await resolveIndices(fresh.map((_, i) => startAt + i), { source: next });
   }
 
+  /**
+   * Manual search goes through /search-to-add — the federated catalogue search
+   * the web app's add flow uses. It was pointed at /resolve, which is the ER
+   * duplicate-checker: it answers "do we already hold this candidate?" and
+   * reports nothing for anything the matcher isn't confident about, which read
+   * as "this doesn't exist" when it usually meant "ask a different question".
+   */
   async function runSearch(query) {
     if (!query.trim()) return;
     setBusy('searching');
     try {
-      // /resolve requires a type; rows carry the parser's inferred_type when it
-      // sent one, otherwise the pitch's own thing_type.
       const type = focusedRow?.inferred_type || thingType;
-      const data = await resolveOne.mutateAsync({ type, title: query.trim() });
-      const res = normalizeResolution(data);
-      // The match leads, then the alternates — `suggestions` excludes the match
-      // itself, so showing only one or the other loses a real option.
-      const list = [res.match, ...res.candidates].filter(
-        (c, i, all) => c && all.findIndex(o => o?.thing_id === c.thing_id) === i,
-      );
-      setSearchResults(list);
-      if (list.length === 0) setNote({ ok: false, text: `No candidates for “${query.trim()}”.` });
+      const results = normalizeSearchResults(await searchToAdd.mutateAsync({ query: query.trim(), type }));
+      setSearchResults(results);
+      if (results.length === 0) {
+        setNote({ ok: false, text: `Nothing found for “${query.trim()}” — try different wording, or leave the row for the target to fix.` });
+      } else if (!results.some(r => r.in_registry)) {
+        setNote({
+          ok: false,
+          text: `Found in ${[...new Set(results.map(r => r.source).filter(Boolean))].join(', ') || 'external sources'} but not in our registry yet, so it can't be attached. Leave the row unresolved and the target gets it as editable text.`,
+        });
+      }
     } catch (err) {
       setNote({ ok: false, text: `Search failed — ${apiErrorMessage(err)}` });
     } finally {
@@ -467,7 +485,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                 <TextInput
                   value={search}
                   onChange={e => setSearch(e.target.value)}
-                  placeholder={`Search registry — “${focusedRow.raw_text.slice(0, 32)}”`}
+                  placeholder={`Search catalogue — “${focusedRow.raw_text.slice(0, 32)}”`}
                 />
                 <Button type="submit" disabled={busy === 'searching'}>
                   Search

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -6,6 +6,7 @@ import {
   chunkForBatch,
   normalizeParsed,
   normalizeResolution,
+  normalizeSearchResults,
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
@@ -269,5 +270,62 @@ describe('rowsFromItems', () => {
 
   it('handles a pitch with no items', () => {
     expect(rowsFromItems(undefined)).toEqual([]);
+  });
+});
+
+describe('federated search results (GET /search-to-add)', () => {
+  // Trimmed from the real shape: registry hits carry a thing_id and sort first,
+  // external hits carry source/source_id and in_registry: false.
+  const RESULTS = {
+    results: [
+      {
+        thing_id: 'movie_the_matrix_1999_14aa79a9',
+        type: 'Movie',
+        title: 'The Matrix',
+        subtitle: 'Lana Wachowski',
+        year: 1999,
+        source: 'local',
+        source_id: null,
+        in_registry: true,
+      },
+      {
+        thing_id: null,
+        type: 'Movie',
+        title: 'The Matrix Resurrections',
+        subtitle: null,
+        year: 2021,
+        source: 'tmdb',
+        source_id: 624860,
+        in_registry: false,
+      },
+    ],
+    count: 2,
+    sources_searched: ['local', 'tmdb_movie'],
+  };
+
+  it('reads registry and external hits, keeping them distinguishable', () => {
+    const [registry, external] = normalizeSearchResults(RESULTS);
+    expect(registry.thing_id).toBe('movie_the_matrix_1999_14aa79a9');
+    expect(registry.in_registry).toBe(true);
+    expect(external.thing_id).toBeNull();
+    expect(external.in_registry).toBe(false);
+    expect(external.source).toBe('tmdb');
+  });
+
+  it('takes the creator from `subtitle`, where this endpoint puts it', () => {
+    expect(normalizeSearchResults(RESULTS)[0].creator).toBe('Lana Wachowski');
+  });
+
+  it('survives an empty or malformed response', () => {
+    expect(normalizeSearchResults({ results: [] })).toEqual([]);
+    expect(normalizeSearchResults(null)).toEqual([]);
+    expect(normalizeSearchResults({ results: 'nope' })).toEqual([]);
+  });
+
+  it('still marks /resolve suggestions as in-registry — they are graph neighbours', () => {
+    // /resolve never sends in_registry; anything it returns with a thing_id is
+    // by definition already in the graph.
+    const res = normalizeResolution({ status: 'no_match', suggestions: [{ thing_id: 'thing_a', title: 'A' }] });
+    expect(res.candidates[0].in_registry).toBe(true);
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -37,6 +37,14 @@ export interface Candidate {
   year: number | string | null;
   image_url: string | null;
   score: number | null;
+  /**
+   * False for a federated hit that exists in TMDB/Spotify/Books but not in our
+   * registry. Those carry no thing_id and cannot be attached to a pitch until
+   * there's a way to materialise a Thing without a list (listgem-platform#550).
+   */
+  in_registry: boolean;
+  /** 'local' for a registry hit, otherwise the external source that found it. */
+  source: string | null;
 }
 
 /** One line in the builder table. The builder holds the ordering. */
@@ -150,11 +158,34 @@ export function normalizeCandidate(raw: unknown): Candidate | null {
     thing_id: thingId,
     title: firstString(src.title, src.name) || '(untitled)',
     type: firstString(src.thing_type, src.type),
-    creator: firstString(src.creator, src.author, src.artist),
+    // `subtitle` is where /search-to-add puts artist/author/director.
+    creator: firstString(src.creator, src.author, src.artist, src.subtitle),
     year: typeof year === 'number' || typeof year === 'string' ? year : null,
     image_url: firstString(src.image_url, src.image),
     score: typeof src.score === 'number' ? src.score : null,
+    // /resolve returns graph neighbours, which are in the registry by
+    // definition; only /search-to-add says so explicitly.
+    in_registry: typeof src.in_registry === 'boolean' ? src.in_registry : !!thingId,
+    source: firstString(src.source),
   };
+}
+
+/**
+ * Results from GET /search-to-add — federated across the registry and the
+ * external catalogues, registry hits sorted first by the API.
+ *
+ * This is the search box. /resolve is a duplicate-checker: it embeds a
+ * candidate and asks the ER matcher whether we already hold it, which answers a
+ * much narrower question and reports "no candidates" for anything the matcher
+ * isn't confident about.
+ */
+export function normalizeSearchResults(data: unknown): Candidate[] {
+  const list = Array.isArray(data)
+    ? data
+    : isObject(data) && Array.isArray(data.results)
+      ? data.results
+      : [];
+  return list.map(normalizeCandidate).filter((c): c is Candidate => c !== null);
 }
 
 /**

--- a/vite.config.js
+++ b/vite.config.js
@@ -11,6 +11,10 @@ export default defineConfig({
         '/auth', '/admin', '/metrics', '/moderation', '/queue-stats', '/feed',
         // Concierge + verification (#533)
         '/pitches', '/verification', '/resolve', '/imports',
+        // Federated catalogue search + the canonical type vocabulary. Absent
+        // here, they 404 against the dev server while working fine in a
+        // production build, which points debugging at entirely the wrong place.
+        '/search-to-add', '/types', '/things',
       ].map(
         (path) => [
           path,


### PR DESCRIPTION
The per-row search called `/resolve` — the ER duplicate-checker from #410. It embeds a candidate and asks the matcher *"do we already hold this?"*, reporting nothing whenever it isn't confident. That reads as **"No candidates"** on titles we demonstrably have, which is what turned up in testing.

Now `GET /search-to-add`: the federated search the web app's own add flow uses — local registry plus TMDB, Spotify, Google Books, Places, Yelp, Amazon, registry hits sorted first. `/resolve` keeps the batch pass, where checking fifty pasted rows against the graph is exactly the right question.

## External hits are shown, not hidden

A federated hit that exists in TMDB but not our registry has no `thing_id` and can't be attached to a pitch until listgem-platform#550. It's still rendered — greyed, marked *not in registry*, with the source named.

Hiding them leaves the operator hunting for something that can't be attached. Showing them says: it exists, we don't hold it, leave the row and the target gets editable text.

## Also

- Reads `subtitle`, which is where this endpoint puts artist/author/director
- Marks `/resolve` suggestions as in-registry — graph neighbours by definition

108 tests, typecheck, lint, build green. **Not yet verified against the live endpoint** — see the PR discussion.