### PR TITLE
Attach things we don't hold yet, and match pasted links (#550)

### DIFF
--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -498,6 +498,24 @@ export function useSearchToAdd() {
   });
 }
 
+/**
+ * Materialise a Thing and get its id back, saying nothing about lists
+ * (listgem-platform#550) — the primitive a pitch draft needs, since it isn't a
+ * list and has no list_id to give the ordinary add paths.
+ *
+ *   { source_type, source_id, type }  a federated-search hit — synchronous
+ *   { url }                           identify only; 404/422 when we don't hold it
+ *
+ * URL mode deliberately does not create: a Thing minted from a pasted link's OG
+ * tags is a permanent low-quality registry entry, and searching routes through
+ * the source APIs instead and produces a better one.
+ */
+export function useResolveOrCreate() {
+  return useMutation({
+    mutationFn: (body) => client.post('/things/resolve-or-create', body).then(r => r.data),
+  });
+}
+
 // --- Verification (#435) ---
 export function useVerifiedUsers({ type = '', limit = 50, offset = 0 } = {}) {
   return useQuery({

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -1,13 +1,20 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import DataTable from '../../components/DataTable';
 import { Button, Field, TextArea, TextInput } from '../../components/Form';
-import { useImportParse, usePitchMutations, useResolveBatch, useSearchToAdd } from '../../api/hooks';
+import {
+  useImportParse,
+  usePitchMutations,
+  useResolveBatch,
+  useResolveOrCreate,
+  useSearchToAdd,
+} from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
 import {
   ROW_STATUS,
   applyBatchResults,
   batchResults,
   chunkForBatch,
+  normalizeCandidate,
   normalizeParsed,
   normalizeSearchResults,
   pendingIndices,
@@ -35,20 +42,20 @@ function Kbd({ children }) {
   );
 }
 
-function CandidateRow({ candidate, chosen, onPick }) {
-  // A federated hit with no thing_id exists in TMDB/Spotify/Books but not in our
-  // registry. Shown rather than hidden — knowing it exists is what tells the
-  // operator to leave the row rather than keep hunting — but not attachable
-  // until listgem-platform#550.
-  const unavailable = !candidate.thing_id;
+function CandidateRow({ candidate, chosen, onPick, busy }) {
+  // A federated hit with no thing_id isn't in our registry yet. Picking it now
+  // materialises it through the same kernel path a user add uses
+  // (listgem-platform#550) — same Thing either way, so the dashed border is a
+  // note about provenance, not a warning.
+  const needsCreate = !candidate.thing_id;
   return (
     <button
-      onClick={unavailable ? undefined : onPick}
-      disabled={unavailable}
-      title={unavailable ? `Found in ${candidate.source || 'an external source'}, not yet in our registry` : undefined}
-      className={`flex w-full items-baseline gap-2 rounded border px-2 py-1 text-left text-xs ${
-        unavailable
-          ? 'cursor-not-allowed border-dashed border-gray-200 text-gray-400'
+      onClick={onPick}
+      disabled={busy}
+      title={needsCreate ? `Not in the registry yet — adds it from ${candidate.source || 'the source'}, then attaches` : undefined}
+      className={`flex w-full items-baseline gap-2 rounded border px-2 py-1 text-left text-xs disabled:opacity-50 ${
+        needsCreate
+          ? 'border-dashed border-gray-300 hover:bg-gray-50'
           : chosen
             ? 'border-indigo-300 bg-indigo-50'
             : 'border-gray-200 hover:bg-gray-50'
@@ -61,7 +68,11 @@ function CandidateRow({ candidate, chosen, onPick }) {
       {candidate.score != null && (
         <span className="tabular-nums text-gray-400">{Number(candidate.score).toFixed(2)}</span>
       )}
-      {unavailable && <span className="shrink-0 text-[10px] uppercase tracking-wide">not in registry</span>}
+      {needsCreate && (
+        <span className="shrink-0 text-[10px] tracking-wide text-gray-400 uppercase">
+          + add from {candidate.source || 'source'}
+        </span>
+      )}
     </button>
   );
 }
@@ -82,10 +93,12 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   const [dirty, setDirty] = useState(false);
   const [search, setSearch] = useState('');
   const [searchResults, setSearchResults] = useState(null);
+  const [urlInput, setUrlInput] = useState('');
 
   const parse = useImportParse();
   const resolveBatch = useResolveBatch();
   const searchToAdd = useSearchToAdd();
+  const resolveOrCreate = useResolveOrCreate();
   const { saveItems } = usePitchMutations(pitchId);
 
   // Re-seed when the server's item set changes identity (detail query settles).
@@ -204,8 +217,8 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         setNote({ ok: false, text: `Nothing found for “${query.trim()}” — try different wording, or leave the row for the target to fix.` });
       } else if (!results.some(r => r.in_registry)) {
         setNote({
-          ok: false,
-          text: `Found in ${[...new Set(results.map(r => r.source).filter(Boolean))].join(', ') || 'external sources'} but not in our registry yet, so it can't be attached. Leave the row unresolved and the target gets it as editable text.`,
+          ok: true,
+          text: `Not in our registry yet, but found in ${[...new Set(results.map(r => r.source).filter(Boolean))].join(', ') || 'external sources'} — picking one adds it and attaches it.`,
         });
       }
     } catch (err) {
@@ -215,14 +228,76 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     }
   }
 
-  function pick(candidate) {
-    patchRow(focus, {
-      thing_id: candidate.thing_id,
-      match: candidate,
-      status: candidate.thing_id ? 'resolved' : 'ambiguous',
-    });
-    setSearchResults(null);
-    setSearch('');
+  /**
+   * Attach a candidate. A registry hit attaches directly; a federated hit is
+   * materialised first through the same kernel path a user add uses, so a Thing
+   * created from a pitch is indistinguishable from one created any other way.
+   */
+  async function pick(candidate) {
+    if (candidate.thing_id) {
+      patchRow(focus, { thing_id: candidate.thing_id, match: candidate, status: 'resolved' });
+      setSearchResults(null);
+      setSearch('');
+      return;
+    }
+    if (!candidate.source_id) {
+      setNote({ ok: false, text: 'That result carries no source id, so it cannot be added.' });
+      return;
+    }
+    setBusy('adding');
+    setNote(null);
+    try {
+      const data = await resolveOrCreate.mutateAsync({
+        source_type: candidate.source_type,
+        source: candidate.source,
+        source_id: candidate.source_id,
+        type: candidate.type || thingType,
+      });
+      const match = normalizeCandidate({ ...(data.thing || {}), thing_id: data.thing_id }) || candidate;
+      patchRow(focus, { thing_id: data.thing_id, match, status: 'resolved' });
+      setSearchResults(null);
+      setSearch('');
+      setNote({
+        ok: true,
+        text: data.created
+          ? `Added “${match.title}” to the registry and attached it.`
+          : `“${match.title}” was already in the registry — attached.`,
+      });
+    } catch (err) {
+      setNote({ ok: false, text: `Could not add that — ${apiErrorMessage(err)}` });
+    } finally {
+      setBusy(null);
+    }
+  }
+
+  /**
+   * Identify a Thing from a pasted link. Deliberately identify-only: the API
+   * will not mint a Thing from a link's metadata, because one built from thin
+   * OG tags is a permanent low-quality registry entry, and searching routes
+   * through the source APIs and produces a better one. A miss says so.
+   */
+  async function resolveFromUrl(url) {
+    if (!url.trim()) return;
+    setBusy('adding');
+    setNote(null);
+    try {
+      const data = await resolveOrCreate.mutateAsync({ url: url.trim() });
+      const match = normalizeCandidate({ ...(data.thing || {}), thing_id: data.thing_id });
+      patchRow(focus, { thing_id: data.thing_id, match, status: 'resolved' });
+      setUrlInput('');
+      setNote({ ok: true, text: `Matched “${match?.title || data.thing_id}” from that link.` });
+    } catch (err) {
+      const status = err?.response?.status;
+      setNote({
+        ok: false,
+        text:
+          status === 404 || status === 422
+            ? `That link doesn't match anything we hold — search by title instead, which goes through the source catalogues and produces a better entry than a crawl would.`
+            : `Link lookup failed — ${apiErrorMessage(err)}`,
+      });
+    } finally {
+      setBusy(null);
+    }
   }
 
   function toggleDrop(index) {
@@ -467,6 +542,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                   key={c.thing_id || i}
                   candidate={c}
                   chosen={c.thing_id && c.thing_id === focusedRow.thing_id}
+                  busy={busy === 'adding'}
                   onPick={() => pick(c)}
                 />
               ))}
@@ -495,13 +571,36 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                 <div className="mt-2 space-y-1">
                   {searchResults.length === 0 && <div className="text-xs text-gray-400">No candidates.</div>}
                   {searchResults.map((c, i) => (
-                    <CandidateRow key={c.thing_id || i} candidate={c} chosen={false} onPick={() => pick(c)} />
+                    <CandidateRow
+                    key={c.thing_id || `${c.source}-${c.source_id}` || i}
+                    candidate={c}
+                    chosen={false}
+                    busy={busy === 'adding'}
+                    onPick={() => pick(c)}
+                  />
                   ))}
                 </div>
               )}
             </div>
             <div>
+              <form
+                className="flex gap-2"
+                onSubmit={e => {
+                  e.preventDefault();
+                  resolveFromUrl(urlInput);
+                }}
+              >
+                <TextInput
+                  value={urlInput}
+                  onChange={e => setUrlInput(e.target.value)}
+                  placeholder="…or paste a link (IMDb, TMDB, Spotify…)"
+                />
+                <Button type="submit" disabled={!!busy || !urlInput.trim()}>
+                  Match
+                </Button>
+              </form>
               <TextInput
+                className="mt-2"
                 value={focusedRow.note || ''}
                 onChange={e => patchRow(focus, { note: e.target.value })}
                 placeholder="Note for this row (internal)"

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -1,0 +1,114 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import client from '../../api/client';
+import PitchBuilder from './PitchBuilder';
+
+vi.mock('../../api/client', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+const ITEMS = [{ raw_text: 'Some obscure film', thing_id: null, resolution_status: 'unresolved', position: 0 }];
+
+// A federated hit that exists in TMDB but not in our registry.
+const EXTERNAL = {
+  results: [
+    {
+      thing_id: null,
+      type: 'Movie',
+      title: 'Obscure Film',
+      subtitle: null,
+      year: 1974,
+      source: 'tmdb',
+      source_type: 'tmdb_movie',
+      source_id: 9911,
+      in_registry: false,
+    },
+  ],
+};
+
+function build() {
+  renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={ITEMS} />);
+}
+
+const searchFor = text => {
+  fireEvent.change(screen.getByPlaceholderText(/Search catalogue/i), { target: { value: text } });
+  fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+};
+
+describe('builder — adding a thing we do not hold yet', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+  });
+
+  it('materialises a federated hit and attaches the returned thing_id', async () => {
+    client.get.mockResolvedValue({ data: EXTERNAL });
+    client.post.mockResolvedValue({
+      data: {
+        thing_id: 'movie_obscure_film_1974_ab12',
+        created: true,
+        via: 'kernel_create',
+        thing: { thing_id: 'movie_obscure_film_1974_ab12', title: 'Obscure Film', type: 'Movie', year: 1974 },
+      },
+    });
+    build();
+    searchFor('Obscure Film');
+
+    fireEvent.click(await screen.findByTitle(/Not in the registry yet/i));
+
+    // Keyed on source_type/source_id — the source mode of the endpoint.
+    await vi.waitFor(() =>
+      expect(client.post).toHaveBeenCalledWith('/things/resolve-or-create', {
+        source_type: 'tmdb_movie',
+        source: 'tmdb',
+        source_id: '9911',
+        type: 'Movie',
+      }),
+    );
+    expect(await screen.findByText(/Added .*Obscure Film.* to the registry/i)).toBeTruthy();
+    expect(screen.getAllByText('Resolved').length).toBeGreaterThan(0);
+  });
+
+  it('matches a pasted link against canonical ids', async () => {
+    client.get.mockRejectedValue(new Error('no search'));
+    client.post.mockResolvedValue({
+      data: {
+        thing_id: 'movie_the_matrix_1999_14aa79a9',
+        created: false,
+        via: 'canonical_id',
+        thing: { thing_id: 'movie_the_matrix_1999_14aa79a9', title: 'The Matrix', type: 'Movie', year: 1999 },
+      },
+    });
+    build();
+    fireEvent.change(screen.getByPlaceholderText(/paste a link/i), {
+      target: { value: 'https://www.imdb.com/title/tt0133093/' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^match$/i }));
+
+    await vi.waitFor(() =>
+      expect(client.post).toHaveBeenCalledWith('/things/resolve-or-create', {
+        url: 'https://www.imdb.com/title/tt0133093/',
+      }),
+    );
+    expect(await screen.findByText(/Matched .*The Matrix/i)).toBeTruthy();
+  });
+
+  it('on a link miss, points at search rather than offering a crawl', async () => {
+    // The API will not mint a Thing from a link's metadata — one built from thin
+    // OG tags is a permanent low-quality registry entry. Searching produces a
+    // better one, so the UI must not offer the worse path.
+    client.get.mockRejectedValue(new Error('no search'));
+    client.post.mockRejectedValue({ response: { status: 404, data: { found: false } } });
+    build();
+    fireEvent.change(screen.getByPlaceholderText(/paste a link/i), {
+      target: { value: 'https://example.com/nothing' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^match$/i }));
+
+    expect(await screen.findByText(/search by title instead/i)).toBeTruthy();
+    // No crawl-and-create affordance: the endpoint supports it behind
+    // { create: true }, and we deliberately don't offer the worse path.
+    expect(screen.queryByRole('button', { name: /crawl|create/i })).toBeNull();
+  });
+});

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -45,6 +45,9 @@ export interface Candidate {
   in_registry: boolean;
   /** 'local' for a registry hit, otherwise the external source that found it. */
   source: string | null;
+  /** e.g. 'tmdb_movie' — what POST /things/resolve-or-create keys on. */
+  source_type: string | null;
+  source_id: string | null;
 }
 
 /** One line in the builder table. The builder holds the ordering. */
@@ -167,6 +170,8 @@ export function normalizeCandidate(raw: unknown): Candidate | null {
     // definition; only /search-to-add says so explicitly.
     in_registry: typeof src.in_registry === 'boolean' ? src.in_registry : !!thingId,
     source: firstString(src.source),
+    source_type: firstString(src.source_type),
+    source_id: src.source_id == null ? null : String(src.source_id),
   };
 }
 


### PR DESCRIPTION
listgem-platform#551 shipped `POST /things/resolve-or-create`. Two things follow.

## Federated hits are attachable

A search result that exists in TMDB but not our registry was rendered greyed and inert. Picking one now materialises it through the same kernel path a user add uses — so a Thing created from a pitch is indistinguishable from one created any other way — then attaches the returned `thing_id`. The dashed border becomes a note about provenance rather than a dead end.

## The URL box is back, and identify-only on purpose

**This is what the IMDb question was actually after.** Canonical ids are read out of the link, so a TMDB-sourced film matches an IMDb URL — the `imdb_id` has been sitting in its canonical ids all along with nothing exposing a lookup.

The endpoint *can* crawl-and-create behind `{ create: true }`, and **the UI deliberately doesn't offer it.** Their reasoning, which I agree with: a Thing minted from a pasted link's OG tags is a permanent low-quality registry entry, while searching routes through the source APIs and produces a better one. So a 404/422 points at search instead. If staff ever hit a case where nothing else reaches, the crawl can be added then — with polling, since it's async.

## Tests

Three against the real response shapes, including that a link miss offers no crawl affordance. 111 total, typecheck, lint, build green.

Same caveat as #22: verified against mocked responses shaped from the route source, not against the live endpoint.