### PR TITLE
Add-by-link adds an item; re-pointing says which row

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -94,6 +94,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   const [search, setSearch] = useState('');
   const [searchResults, setSearchResults] = useState(null);
   const [urlInput, setUrlInput] = useState('');
+  const [addUrl, setAddUrl] = useState('');
 
   const parse = useImportParse();
   const resolveBatch = useResolveBatch();
@@ -206,6 +207,49 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
    * reports nothing for anything the matcher isn't confident about, which read
    * as "this doesn't exist" when it usually meant "ask a different question".
    */
+  /**
+   * Add a new item from a link. Distinct from the row editor's link box, which
+   * re-points an existing row — pasting a link to "add this film" is what the
+   * web app's composer does, so the builder needs to mean the same thing.
+   */
+  async function addRowFromUrl(url) {
+    if (!url.trim()) return;
+    setBusy('adding');
+    setNote(null);
+    try {
+      const data = await resolveOrCreate.mutateAsync({ url: url.trim() });
+      const match = normalizeCandidate({ ...(data.thing || {}), thing_id: data.thing_id });
+      const row = {
+        raw_text: match?.title || url.trim(),
+        thing_id: data.thing_id,
+        status: 'resolved',
+        candidates: [],
+        match,
+        note: '',
+        dropped: false,
+        inferred_type: match?.type || null,
+        confidence: null,
+        reason: null,
+      };
+      setRows(rs => [...rs, row]);
+      setFocus(rows.length);
+      setDirty(true);
+      setAddUrl('');
+      setNote({ ok: true, text: `Added “${row.raw_text}” as item ${rows.length + 1}.` });
+    } catch (err) {
+      const status = err?.response?.status;
+      setNote({
+        ok: false,
+        text:
+          status === 404 || status === 422
+            ? `That link doesn't match anything we hold — search by title instead, which goes through the source catalogues and produces a better entry than a crawl would.`
+            : `Could not add from that link — ${apiErrorMessage(err)}`,
+      });
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function runSearch(query) {
     if (!query.trim()) return;
     setBusy('searching');
@@ -283,9 +327,18 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     try {
       const data = await resolveOrCreate.mutateAsync({ url: url.trim() });
       const match = normalizeCandidate({ ...(data.thing || {}), thing_id: data.thing_id });
+      const replaced = focusedRow?.match?.title;
       patchRow(focus, { thing_id: data.thing_id, match, status: 'resolved' });
       setUrlInput('');
-      setNote({ ok: true, text: `Matched “${match?.title || data.thing_id}” from that link.` });
+      // Name the row and what it replaced: this changes one existing row rather
+      // than adding an item, and an unannounced overwrite of a correct match is
+      // the expensive mistake here.
+      setNote({
+        ok: true,
+        text: `Row ${focus + 1} now matches “${match?.title || data.thing_id}”${
+          replaced && replaced !== match?.title ? ` — replaced “${replaced}”` : ''
+        }.`,
+      });
     } catch (err) {
       const status = err?.response?.status;
       setNote({
@@ -449,7 +502,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       {/* Toolbar */}
       {!readOnly && (
         <div className="flex flex-wrap items-center gap-2">
-          <Button onClick={() => setShowPaste(s => !s)}>{showPaste ? 'Hide paste box' : 'Paste more text'}</Button>
+          <Button onClick={() => setShowPaste(s => !s)}>{showPaste ? 'Hide add panel' : 'Add items'}</Button>
           <Button
             disabled={unresolvedIndices.length === 0 || !!busy}
             onClick={() => resolveIndices(unresolvedIndices)}
@@ -505,6 +558,30 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
               </Button>
             )}
           </div>
+
+          <form
+            className="mt-3 border-t border-gray-100 pt-3"
+            onSubmit={e => {
+              e.preventDefault();
+              addRowFromUrl(addUrl);
+            }}
+          >
+            <Field
+              label="Or add one item by link"
+              hint="IMDb, TMDB, Spotify… Matched on the identifier in the link, so an IMDb URL finds a film we ingested from TMDB. Appends a new item."
+            >
+              <div className="flex gap-2">
+                <TextInput
+                  value={addUrl}
+                  onChange={e => setAddUrl(e.target.value)}
+                  placeholder="https://www.imdb.com/title/tt0114814/"
+                />
+                <Button type="submit" disabled={!!busy || !addUrl.trim()}>
+                  {busy === 'adding' ? 'Adding…' : 'Add item'}
+                </Button>
+              </div>
+            </Field>
+          </form>
         </div>
       )}
 
@@ -593,10 +670,10 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                 <TextInput
                   value={urlInput}
                   onChange={e => setUrlInput(e.target.value)}
-                  placeholder="…or paste a link (IMDb, TMDB, Spotify…)"
+                  placeholder={`Re-point row ${focus + 1} using a link`}
                 />
                 <Button type="submit" disabled={!!busy || !urlInput.trim()}>
-                  Match
+                  Re-point
                 </Button>
               </form>
               <TextInput

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -70,6 +70,55 @@ describe('builder — adding a thing we do not hold yet', () => {
     expect(screen.getAllByText('Resolved').length).toBeGreaterThan(0);
   });
 
+  it('adds a NEW item from a link rather than re-pointing an existing row', async () => {
+    // Reported: pasting an IMDb link said "Matched The Usual Suspects" and
+    // nothing appeared in the list — because the only link box re-pointed the
+    // focused row, silently replacing whatever it already matched.
+    client.get.mockRejectedValue(new Error('no search'));
+    client.post.mockResolvedValue({
+      data: {
+        thing_id: 'movie_usual_suspects_1995_c3',
+        created: false,
+        via: 'canonical_id',
+        thing: { thing_id: 'movie_usual_suspects_1995_c3', title: 'The Usual Suspects', type: 'Movie', year: 1995 },
+      },
+    });
+    build();
+    // The add panel is collapsed once a pitch has items — this is the path an
+    // operator takes to add one more.
+    fireEvent.click(screen.getByRole('button', { name: /add items/i }));
+
+    fireEvent.change(screen.getByPlaceholderText(/imdb\.com\/title/i), {
+      target: { value: 'https://www.imdb.com/title/tt0114814/' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /add item/i }));
+
+    expect(await screen.findByText(/Added .*The Usual Suspects.* as item 2/i)).toBeTruthy();
+    // The original row is untouched, and there are now two.
+    expect(screen.getByText('Some obscure film')).toBeTruthy();
+    expect(screen.getAllByText('The Usual Suspects').length).toBeGreaterThan(0);
+  });
+
+  it('names the row and what it replaced when re-pointing', async () => {
+    client.get.mockRejectedValue(new Error('no search'));
+    client.post.mockResolvedValue({
+      data: {
+        thing_id: 'movie_usual_suspects_1995_c3',
+        created: false,
+        thing: { thing_id: 'movie_usual_suspects_1995_c3', title: 'The Usual Suspects', type: 'Movie' },
+      },
+    });
+    build();
+    fireEvent.change(screen.getByPlaceholderText(/Re-point row 1/i), {
+      target: { value: 'https://www.imdb.com/title/tt0114814/' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /re-point/i }));
+
+    // Says which row changed — an unannounced overwrite of a correct match is
+    // the expensive mistake here.
+    expect(await screen.findByText(/Row 1 now matches .*The Usual Suspects/i)).toBeTruthy();
+  });
+
   it('matches a pasted link against canonical ids', async () => {
     client.get.mockRejectedValue(new Error('no search'));
     client.post.mockResolvedValue({
@@ -81,17 +130,17 @@ describe('builder — adding a thing we do not hold yet', () => {
       },
     });
     build();
-    fireEvent.change(screen.getByPlaceholderText(/paste a link/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Re-point row 1/i), {
       target: { value: 'https://www.imdb.com/title/tt0133093/' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /^match$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /re-point/i }));
 
     await vi.waitFor(() =>
       expect(client.post).toHaveBeenCalledWith('/things/resolve-or-create', {
         url: 'https://www.imdb.com/title/tt0133093/',
       }),
     );
-    expect(await screen.findByText(/Matched .*The Matrix/i)).toBeTruthy();
+    expect(await screen.findByText(/Row 1 now matches .*The Matrix/i)).toBeTruthy();
   });
 
   it('on a link miss, points at search rather than offering a crawl', async () => {
@@ -101,10 +150,10 @@ describe('builder — adding a thing we do not hold yet', () => {
     client.get.mockRejectedValue(new Error('no search'));
     client.post.mockRejectedValue({ response: { status: 404, data: { found: false } } });
     build();
-    fireEvent.change(screen.getByPlaceholderText(/paste a link/i), {
+    fireEvent.change(screen.getByPlaceholderText(/Re-point row 1/i), {
       target: { value: 'https://example.com/nothing' },
     });
-    fireEvent.click(screen.getByRole('button', { name: /^match$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /re-point/i }));
 
     expect(await screen.findByText(/search by title instead/i)).toBeTruthy();
     // No crawl-and-create affordance: the endpoint supports it behind


### PR DESCRIPTION
**Reported:** pasting an IMDb link said *"Matched The Usual Suspects"* and nothing appeared in the list.

Nothing was meant to. The only link box lived in the focused-row editor and **re-pointed that row** — silently replacing whatever row 1 already matched, and reporting success while doing it.

Two failures at once:

1. **The affordance reads as "add by link"**, because that is exactly what it does in the web app's composer. Expecting it to add an item is the correct expectation; the builder was the odd one out.
2. **The overwrite named neither the row nor what it displaced.** Same class of harm as the lone-suggestion trap — a wrong entry on a list we're about to show its supposed author, arrived at silently.

## Both paths now exist, and say which they are

- **"Or add one item by link"** — in the add panel beside the paste box. Appends a new item. What a link paste means everywhere else in the product.
- **The row editor's box** is now labelled *"Re-point row N using a link"*, and its confirmation reads *"Row N now matches X — replaced Y"*.

The toolbar button becomes **Add items** rather than *Paste more text*, since that panel is now the way in for both text and links.

113 tests, including one pinning the reported symptom: adding by link leaves the existing row untouched and appends a second.