### PR TITLE
Make the add panel findable

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -502,7 +502,16 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       {/* Toolbar */}
       {!readOnly && (
         <div className="flex flex-wrap items-center gap-2">
-          <Button onClick={() => setShowPaste(s => !s)}>{showPaste ? 'Hide add panel' : 'Add items'}</Button>
+          {/* The only control in this row that brings new content in; the rest act
+              on what's already there. Styled apart because it was being lost
+              among them — the add-by-link box lives inside this panel, and an
+              operator looking for it couldn't find it. */}
+          <Button
+            onClick={() => setShowPaste(s => !s)}
+            className="border-indigo-300 bg-indigo-50 text-indigo-700 hover:bg-indigo-100"
+          >
+            {showPaste ? '× Hide add panel' : '+ Add items or a link'}
+          </Button>
           <Button
             disabled={unresolvedIndices.length === 0 || !!busy}
             onClick={() => resolveIndices(unresolvedIndices)}

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -86,7 +86,7 @@ describe('builder — adding a thing we do not hold yet', () => {
     build();
     // The add panel is collapsed once a pitch has items — this is the path an
     // operator takes to add one more.
-    fireEvent.click(screen.getByRole('button', { name: /add items/i }));
+    fireEvent.click(screen.getByRole('button', { name: /add items or a link/i }));
 
     fireEvent.change(screen.getByPlaceholderText(/imdb\.com\/title/i), {
       target: { value: 'https://www.imdb.com/title/tt0114814/' },


### PR DESCRIPTION
The add-by-link box lives inside the add panel, behind a toggle button styled identically to the three action buttons beside it. An operator looking for it went round twice and concluded the feature wasn't there.

That toolbar row has exactly one control that brings new content in and three that act on what's already present. The first is now styled apart and says what it opens: **+ Add items or a link**.

Not changed: the repair box in the row editor is visible by default while the add box is behind a toggle — the more common action being the harder to reach. Unhiding both invites exactly the confusion #24 just fixed, so leaving it until it demonstrably costs more time.

Playbook updated alongside (listgem-website#102), per the rule in docs/concierge-admin.md.

113 tests, lint, build green.