### PR TITLE
Stop sending list decoration to the matcher; show confidence

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -17,6 +17,7 @@ import {
   normalizeCandidate,
   normalizeParsed,
   normalizeSearchResults,
+  searchTitle,
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
@@ -28,6 +29,10 @@ import {
 // The 60s server deadline for `pending`, walked in widening steps. Re-request
 // those indices — a pending row is not an unresolved row.
 const RECHECK_DELAYS_MS = [6000, 10000, 14000, 20000, 20000];
+
+// Below this, a "Resolved" row is worth a second look before it reaches the
+// target. Not a threshold the API applies — purely a prompt to the operator.
+const LOW_CONFIDENCE = 0.7;
 
 function StatusPill({ status }) {
   const spec = ROW_STATUS[status] || ROW_STATUS.unresolved;
@@ -431,7 +436,28 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
           <span className="text-gray-300">—</span>
         ),
     },
-    { key: 'status', header: 'Status', width: 'w-24', render: row => <StatusPill status={row.status} /> },
+    {
+      key: 'status',
+      header: 'Status',
+      width: 'w-32',
+      render: row => (
+        <span className="flex items-center gap-1.5">
+          <StatusPill status={row.status} />
+          {/* A match at 0.4 and one at 1.0 both read as "Resolved" otherwise —
+              and a confident-looking wrong match is the expensive kind. */}
+          {row.confidence != null && row.status === 'resolved' && (
+            <span
+              className={`text-[11px] tabular-nums ${
+                row.confidence < LOW_CONFIDENCE ? 'font-medium text-amber-600' : 'text-gray-400'
+              }`}
+              title={row.confidence < LOW_CONFIDENCE ? 'Low confidence — check the year and creator' : 'Match confidence'}
+            >
+              {Number(row.confidence).toFixed(2)}
+            </span>
+          )}
+        </span>
+      ),
+    },
     {
       key: 'cands',
       header: 'Alts',
@@ -641,13 +667,13 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                 className="flex gap-2"
                 onSubmit={e => {
                   e.preventDefault();
-                  runSearch(search || focusedRow.raw_text);
+                  runSearch(search || searchTitle(focusedRow.raw_text));
                 }}
               >
                 <TextInput
                   value={search}
                   onChange={e => setSearch(e.target.value)}
-                  placeholder={`Search catalogue — “${focusedRow.raw_text.slice(0, 32)}”`}
+                  placeholder={`Search catalogue — “${searchTitle(focusedRow.raw_text).slice(0, 32)}”`}
                 />
                 <Button type="submit" disabled={busy === 'searching'}>
                   Search
@@ -695,7 +721,16 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                 Resolving as <span className="font-medium text-gray-500">{focusedRow.inferred_type || thingType}</span>
                 {focusedRow.reason && <> · server said <span className="text-gray-500">{focusedRow.reason}</span></>}
                 {focusedRow.confidence != null && (
-                  <> · confidence <span className="tabular-nums text-gray-500">{focusedRow.confidence}</span></>
+                  <>
+                    {' '}· confidence{' '}
+                    <span
+                      className={`tabular-nums ${
+                        focusedRow.confidence < LOW_CONFIDENCE ? 'font-medium text-amber-600' : 'text-gray-500'
+                      }`}
+                    >
+                      {Number(focusedRow.confidence).toFixed(2)}
+                    </span>
+                  </>
                 )}
               </div>
             </div>

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -10,6 +10,7 @@ import {
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
+  searchTitle,
   summarize,
   toBatchPayload,
   toItemsPayload,
@@ -327,5 +328,45 @@ describe('federated search results (GET /search-to-add)', () => {
     // by definition already in the graph.
     const res = normalizeResolution({ status: 'no_match', suggestions: [{ thing_id: 'thing_a', title: 'A' }] });
     expect(res.candidates[0].in_registry).toBe(true);
+  });
+});
+
+describe('searchTitle — list decoration wrecks the match', () => {
+  // Real rows from a Nordic-noir source list. Sending the whole string as the
+  // title collapsed the trigram similarity, widened the vector distance, and
+  // filterSuggestions then dropped the alternates too — so a wrong match
+  // arrived with nothing to correct it.
+  it('strips ratings and flags, keeps the title and year', () => {
+    expect(searchTitle('Persona (1966) 🇸🇪 8.6/10')).toBe('Persona (1966)');
+    expect(searchTitle('Fanny & Alexander (1982) 🇸🇪 9.1/10')).toBe('Fanny & Alexander (1982)');
+    expect(searchTitle('The Hunt (2012) 🇩🇰 8.5/10')).toBe('The Hunt (2012)');
+  });
+
+  it('strips leading list decoration the parser leaves behind', () => {
+    expect(searchTitle('1. The Celebration (1998)')).toBe('The Celebration (1998)');
+    expect(searchTitle('— Let the Right One In')).toBe('Let the Right One In');
+    expect(searchTitle('• Insomnia')).toBe('Insomnia');
+  });
+
+  it('handles other rating notations', () => {
+    expect(searchTitle('Dune 4/5')).toBe('Dune');
+    expect(searchTitle('Sapiens 92%')).toBe('Sapiens');
+  });
+
+  it('leaves a clean title alone', () => {
+    expect(searchTitle('The Matrix')).toBe('The Matrix');
+    expect(searchTitle("The Emigrants + The New Land (1971, 1972)")).toBe('The Emigrants + The New Land (1971, 1972)');
+  });
+
+  it('never returns junk for junk', () => {
+    expect(searchTitle('')).toBe('');
+    expect(searchTitle('   🇸🇪  8.6/10 ')).toBe('');
+  });
+
+  it('is what the batch payload sends, while raw_text is preserved', () => {
+    const rows = rowsFromParsed([{ position: 0, raw_text: 'Persona (1966) 🇸🇪 8.6/10', inferred_type: null }]);
+    expect(toBatchPayload(rows, [0], 'Movie')).toEqual([{ type: 'Movie', title: 'Persona (1966)' }]);
+    // The operator still sees what they pasted, and so does the target.
+    expect(rows[0].raw_text).toBe('Persona (1966) 🇸🇪 8.6/10');
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -283,6 +283,33 @@ export function chunkForBatch(indices: number[], size: number = BATCH_LIMIT): nu
 }
 
 /**
+ * The text to match on, cleaned of list decoration.
+ *
+ * Source lists carry ratings, flags and bullets — `Persona (1966) 🇸🇪 8.6/10`.
+ * Sending that whole string as the title degrades every stage: the ER matcher's
+ * trigram similarity collapses, the vector distance widens, and
+ * `filterSuggestions` then drops the alternates too, so a bad match arrives with
+ * nothing to correct it. Short titles suffer worst — the noise outweighs them.
+ *
+ * `raw_text` is left untouched: it's what the operator recognises, and what the
+ * target inherits on an unresolved row.
+ */
+export function searchTitle(rawText: string): string {
+  return (rawText || '')
+    // leading list decoration the parser may leave behind
+    .replace(/^\s*(?:\d+[.)]|[-*•–—])\s*/, '')
+    // ratings: 8.6/10, 4/5, 92%
+    .replace(/\b\d+(?:\.\d+)?\s*\/\s*\d+\b/g, '')
+    .replace(/\b\d{1,3}\s*%/g, '')
+    // emoji and flags (regional indicators, pictographs, misc symbols)
+    .replace(/[\u{1F1E6}-\u{1F1FF}\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{FE0F}]/gu, '')
+    // whatever separators the decoration left stranded
+    .replace(/\s*[|·–—-]\s*$/, '')
+    .replace(/\s{2,}/g, ' ')
+    .trim();
+}
+
+/**
  * `candidates` for POST /resolve/batch. `type` is required per candidate, and
  * the builder has no per-row type of its own — it uses the parser's
  * `inferred_type` when there is one and the pitch's `thing_type` otherwise.
@@ -294,7 +321,7 @@ export function toBatchPayload(
 ): ResolveRequest[] {
   return indices.map(rowIndex => ({
     type: rows[rowIndex].inferred_type || fallbackType,
-    title: rows[rowIndex].raw_text,
+    title: searchTitle(rows[rowIndex].raw_text),
   }));
 }
 


### PR DESCRIPTION
From a real six-item build, three symptoms:

- `Persona (1966) 🇸🇪 8.6/10` → **Unresolved**, though TMDB certainly has it
- `The Emigrants + The New Land (1971, 1972)` → **Resolved**, confidently, to *"Coming to America: Jan Troell on 'The Emigrants' and 'The New Land'"* (2016) — a documentary **about** those films
- The **Alts** column empty on every row

**One cause.** We sent the entire pasted string as the title. The matcher is trigram-plus-vector, so ratings and flags collapse the trigram similarity and widen the vector distance. And `filterSuggestions` drops alternates on those same criteria — which is why a bad match arrived with nothing to correct it. Short titles suffer worst: `Persona` is outweighed by its own decoration, while `Fanny & Alexander` survived the identical treatment.

`searchTitle()` strips ratings (`8.6/10`, `4/5`, `92%`), emoji and flags, leading bullets and numbering, and stranded separators. It **keeps the year** — every row that did resolve carried one. `raw_text` is untouched: it's what the operator recognises, and what the target inherits on an unresolved row.

## Confidence is now visible

The API returns it per row and we were storing it without showing it. A match at 0.4 and one at 1.0 both read as **Resolved**, and the confident-looking wrong match is the expensive kind — it reaches the target as evidence we understood their work. Below 0.7 renders amber, with a prompt to check the year and creator.

Tests run `searchTitle` against the exact strings that failed. 119 total, typecheck, lint, build green.

Worth saying: this only reduces the odds of a wrong match. Row 2 may still mismatch — the fix that catches that one is the operator reading the year, which the confidence colour is there to prompt.