### PR TITLE
A link we understood but don't hold runs the search itself

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -255,20 +255,23 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     }
   }
 
-  async function runSearch(query) {
+  async function runSearch(query, { context = '' } = {}) {
     if (!query.trim()) return;
     setBusy('searching');
     try {
       const type = focusedRow?.inferred_type || thingType;
       const results = normalizeSearchResults(await searchToAdd.mutateAsync({ query: query.trim(), type }));
       setSearchResults(results);
+      const sources = [...new Set(results.map(r => r.source).filter(Boolean))].join(', ');
       if (results.length === 0) {
-        setNote({ ok: false, text: `Nothing found for “${query.trim()}” — try different wording, or leave the row for the target to fix.` });
+        setNote({ ok: false, text: `${context}nothing found for “${query.trim()}” — try different wording, or leave the row for the target to fix.` });
       } else if (!results.some(r => r.in_registry)) {
         setNote({
           ok: true,
-          text: `Not in our registry yet, but found in ${[...new Set(results.map(r => r.source).filter(Boolean))].join(', ') || 'external sources'} — picking one adds it and attaches it.`,
+          text: `${context}found in ${sources || 'the source catalogues'} — picking one adds it and attaches it.`,
         });
+      } else if (context) {
+        setNote({ ok: true, text: `${context}found ${results.length} result(s) below.` });
       }
     } catch (err) {
       setNote({ ok: false, text: `Search failed — ${apiErrorMessage(err)}` });
@@ -346,11 +349,27 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       });
     } catch (err) {
       const status = err?.response?.status;
+      const ids = err?.response?.data?.canonical_ids;
+      const idText = ids && Object.keys(ids).length
+        ? Object.entries(ids).map(([k, v]) => `${k} ${v}`).join(', ')
+        : null;
+      if (status === 404) {
+        // We read the identifier and don't hold the thing — a coverage gap, not
+        // a bad link. Searching finds it in the source catalogues, where one
+        // click adds it, so run that search rather than describing it. The
+        // context rides along so the search's own note doesn't erase the fact
+        // that the link WAS understood.
+        setBusy(null);
+        await runSearch(searchTitle(focusedRow?.raw_text || ''), {
+          context: `Link read${idText ? ` (${idText})` : ''} but not in our registry — `,
+        });
+        return;
+      }
       setNote({
         ok: false,
         text:
-          status === 404 || status === 422
-            ? `That link doesn't match anything we hold — search by title instead, which goes through the source catalogues and produces a better entry than a crawl would.`
+          status === 422
+            ? `No identifier in that link — we can read IMDb, TMDB and Spotify links. Search by title instead.`
             : `Link lookup failed — ${apiErrorMessage(err)}`,
       });
     } finally {

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -143,22 +143,41 @@ describe('builder — adding a thing we do not hold yet', () => {
     expect(await screen.findByText(/Row 1 matched to .*The Matrix/i)).toBeTruthy();
   });
 
-  it('on a link miss, points at search rather than offering a crawl', async () => {
-    // The API will not mint a Thing from a link's metadata — one built from thin
-    // OG tags is a permanent low-quality registry entry. Searching produces a
-    // better one, so the UI must not offer the worse path.
-    client.get.mockRejectedValue(new Error('no search'));
-    client.post.mockRejectedValue({ response: { status: 404, data: { found: false } } });
+  it('on a 404 says what it read, then runs the search itself', async () => {
+    // A 404 means we read the identifier and don't hold the thing — a coverage
+    // gap, not a bad link. The film is in TMDB, so searching lands the operator
+    // on a result they can add in one click. Describing that is worse than
+    // doing it.
+    client.post.mockRejectedValue({
+      response: { status: 404, data: { found: false, canonical_ids: { imdb_id: 'tt0060827' } } },
+    });
+    client.get.mockResolvedValue({
+      data: { results: [{ thing_id: null, title: 'Persona', type: 'Movie', year: 1966, source: 'tmdb', source_type: 'tmdb_movie', source_id: 605, in_registry: false }] },
+    });
     build();
     fireEvent.change(screen.getByPlaceholderText(/Match row 1 using a link/i), {
-      target: { value: 'https://example.com/nothing' },
+      target: { value: 'https://www.imdb.com/title/tt0060827/?ref_=fn_t_2' },
     });
     fireEvent.click(screen.getByRole('button', { name: /^match$/i }));
 
-    expect(await screen.findByText(/search by title instead/i)).toBeTruthy();
-    // No crawl-and-create affordance: the endpoint supports it behind
-    // { create: true }, and we deliberately don't offer the worse path.
-    expect(screen.queryByRole('button', { name: /crawl|create/i })).toBeNull();
+    expect(await screen.findByText(/Link read \(imdb_id tt0060827\) but not in our registry/i)).toBeTruthy();
+    // …and the search ran, so the addable result is already on screen.
+    expect(await screen.findByTitle(/Not in the registry yet/i)).toBeTruthy();
+    // Still no crawl-and-create affordance: the API supports it behind
+    // { create: true } and it produces a worse entry than the source APIs.
+    expect(screen.queryByRole('button', { name: /crawl/i })).toBeNull();
+  });
+
+  it('a link with no identifier is a different problem, and says so', async () => {
+    client.get.mockRejectedValue(new Error('no search'));
+    client.post.mockRejectedValue({ response: { status: 422, data: { error: 'No canonical id in that URL' } } });
+    build();
+    fireEvent.change(screen.getByPlaceholderText(/Match row 1 using a link/i), {
+      target: { value: 'https://example.com/some-blog-post' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^match$/i }));
+
+    expect(await screen.findByText(/No identifier in that link/i)).toBeTruthy();
   });
 });
 


### PR DESCRIPTION
Pasting the IMDb link for Persona returned *"That link doesn't match anything we hold — search by title instead."* Two things wrong with it.

**It conflated two different failures.** The API answers **422** when it can't read an identifier from the link, and **404** when it read one fine and we don't hold the thing. Persona was a 404 — I ran the URL through the backend's extractor and `imdb_id tt0060827` parses correctly. The operator was told to doubt their link when the link was perfect and the *registry* was the gap.

**It described the next step instead of taking it.** Persona is in TMDB, so the search that message recommends finds it and offers one-click add. The 404 branch now runs that search itself:

> Link read (imdb_id tt0060827) but not in our registry — found in tmdb — picking one adds it and attaches it.

The context is passed into `runSearch` rather than set as a note first, because the search's own note would have overwritten it and lost the one fact worth keeping: the link *was* understood.

**422 now says what it means** — no identifier in the link, and which sites we can read.

122 tests, both branches pinned.