### PR TITLE
Send the year as a field, not inside the title

### DIFF
--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -10,6 +10,7 @@ import {
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
+  extractYear,
   searchTitle,
   summarize,
   toBatchPayload,
@@ -96,6 +97,9 @@ describe('the shapes prod actually returns', () => {
       { type: 'Movie', title: 'The Matrix' },
       { type: 'TVSeries', title: 'Slow Horses' },
     ]);
+    // …and the year rides as its own field when the text carries one.
+    const dated = rowsFromParsed([{ position: 0, raw_text: 'Arrival (2016)', inferred_type: null }]);
+    expect(toBatchPayload(dated, [0], 'Movie')).toEqual([{ type: 'Movie', title: 'Arrival', year: 2016 }]);
   });
 });
 
@@ -336,14 +340,23 @@ describe('searchTitle — list decoration wrecks the match', () => {
   // title collapsed the trigram similarity, widened the vector distance, and
   // filterSuggestions then dropped the alternates too — so a wrong match
   // arrived with nothing to correct it.
-  it('strips ratings and flags, keeps the title and year', () => {
-    expect(searchTitle('Persona (1966) 🇸🇪 8.6/10')).toBe('Persona (1966)');
-    expect(searchTitle('Fanny & Alexander (1982) 🇸🇪 9.1/10')).toBe('Fanny & Alexander (1982)');
-    expect(searchTitle('The Hunt (2012) 🇩🇰 8.5/10')).toBe('The Hunt (2012)');
+  it('strips ratings, flags and the year, leaving a bare title', () => {
+    // Registry titles are bare, and TMDB's search doesn't parse "(1966)" — it
+    // matched nothing at all for Persona. The year travels as its own field.
+    expect(searchTitle('Persona (1966) 🇸🇪 8.6/10')).toBe('Persona');
+    expect(searchTitle('Fanny & Alexander (1982) 🇸🇪 9.1/10')).toBe('Fanny & Alexander');
+    expect(searchTitle('The Hunt (2012) 🇩🇰 8.5/10')).toBe('The Hunt');
+    expect(searchTitle('The Emigrants + The New Land (1971, 1972)')).toBe('The Emigrants + The New Land');
+  });
+
+  it('pulls the year out separately', () => {
+    expect(extractYear('Persona (1966) 🇸🇪 8.6/10')).toBe(1966);
+    expect(extractYear('The Emigrants + The New Land (1971, 1972)')).toBe(1971);
+    expect(extractYear('The Matrix')).toBeNull();
   });
 
   it('strips leading list decoration the parser leaves behind', () => {
-    expect(searchTitle('1. The Celebration (1998)')).toBe('The Celebration (1998)');
+    expect(searchTitle('1. The Celebration (1998)')).toBe('The Celebration');
     expect(searchTitle('— Let the Right One In')).toBe('Let the Right One In');
     expect(searchTitle('• Insomnia')).toBe('Insomnia');
   });
@@ -355,7 +368,7 @@ describe('searchTitle — list decoration wrecks the match', () => {
 
   it('leaves a clean title alone', () => {
     expect(searchTitle('The Matrix')).toBe('The Matrix');
-    expect(searchTitle("The Emigrants + The New Land (1971, 1972)")).toBe('The Emigrants + The New Land (1971, 1972)');
+    expect(searchTitle('The Matrix Reloaded')).toBe('The Matrix Reloaded');
   });
 
   it('never returns junk for junk', () => {
@@ -365,7 +378,7 @@ describe('searchTitle — list decoration wrecks the match', () => {
 
   it('is what the batch payload sends, while raw_text is preserved', () => {
     const rows = rowsFromParsed([{ position: 0, raw_text: 'Persona (1966) 🇸🇪 8.6/10', inferred_type: null }]);
-    expect(toBatchPayload(rows, [0], 'Movie')).toEqual([{ type: 'Movie', title: 'Persona (1966)' }]);
+    expect(toBatchPayload(rows, [0], 'Movie')).toEqual([{ type: 'Movie', title: 'Persona', year: 1966 }]);
     // The operator still sees what they pasted, and so does the target.
     expect(rows[0].raw_text).toBe('Persona (1966) 🇸🇪 8.6/10');
   });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -85,6 +85,7 @@ export interface ParsedCandidate {
 export interface ResolveRequest {
   type: string;
   title: string;
+  year?: number;
 }
 
 /** PUT /pitches/:id/items element. `resolution_status` is only ever these two. */
@@ -291,6 +292,11 @@ export function chunkForBatch(indices: number[], size: number = BATCH_LIMIT): nu
  * `filterSuggestions` then drops the alternates too, so a bad match arrives with
  * nothing to correct it. Short titles suffer worst — the noise outweighs them.
  *
+ * The year comes out too, and travels as its own field — see `extractYear`.
+ * Registry titles are bare ("Persona", not "Persona (1966)"), so a parenthetical
+ * year lowers the trigram similarity it was meant to sharpen, and TMDB's search
+ * doesn't parse it at all: "Persona (1966)" matches nothing there.
+ *
  * `raw_text` is left untouched: it's what the operator recognises, and what the
  * target inherits on an unresolved row.
  */
@@ -303,10 +309,18 @@ export function searchTitle(rawText: string): string {
     .replace(/\b\d{1,3}\s*%/g, '')
     // emoji and flags (regional indicators, pictographs, misc symbols)
     .replace(/[\u{1F1E6}-\u{1F1FF}\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{FE0F}]/gu, '')
+    // a trailing year, or a run of them: "(1971, 1972)"
+    .replace(/\s*\((?:\s*(?:19|20)\d{2}\s*,?)+\)\s*/g, ' ')
     // whatever separators the decoration left stranded
     .replace(/\s*[|·–—-]\s*$/, '')
     .replace(/\s{2,}/g, ' ')
     .trim();
+}
+
+/** The first four-digit year in the text, which the API takes as its own field. */
+export function extractYear(rawText: string): number | null {
+  const m = (rawText || '').match(/\b(19|20)\d{2}\b/);
+  return m ? Number(m[0]) : null;
 }
 
 /**
@@ -319,10 +333,15 @@ export function toBatchPayload(
   indices: number[],
   fallbackType: string,
 ): ResolveRequest[] {
-  return indices.map(rowIndex => ({
-    type: rows[rowIndex].inferred_type || fallbackType,
-    title: searchTitle(rows[rowIndex].raw_text),
-  }));
+  return indices.map(rowIndex => {
+    const raw = rows[rowIndex].raw_text;
+    const year = extractYear(raw);
+    return {
+      type: rows[rowIndex].inferred_type || fallbackType,
+      title: searchTitle(raw),
+      ...(year ? { year } : {}),
+    };
+  });
 }
 
 /** Unwrap the batch response container — array, `{ results }` or `{ items }`. */


### PR DESCRIPTION
Persona's IMDb link came back *not in our registry*, and the automatic search that followed found **nothing at all** — including in TMDB, which certainly has it.

`searchTitle` was keeping the parenthetical year. TMDB's search doesn't parse `Persona (1966)`; it matches the literal string and returns nothing. Registry titles are bare as well, so the year was *lowering* the trigram similarity it looked like it should sharpen. Long titles absorbed it — `Fanny & Alexander (1982)` resolved fine — and short ones drowned in it.

`/resolve` has accepted `{ type, title, year }` all along. The year goes there now: `searchTitle` returns a bare title, `extractYear` pulls the first four-digit year, `toBatchPayload` sends both. `(1971, 1972)` yields `1971`.

**This is the second defect in the same row, and last time I fixed half of it.** I stripped the decoration *around* the title and left the decoration *inside* it, with no evidence either way about the year. The evidence arrived when the search returned nothing for a film TMDB definitely holds.

123 tests.