### PR TITLE
Unresolved rows arrive with their search already run

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -34,6 +34,11 @@ const RECHECK_DELAYS_MS = [6000, 10000, 14000, 20000, 20000];
 // target. Not a threshold the API applies — purely a prompt to the operator.
 const LOW_CONFIDENCE = 0.7;
 
+// How long focus must settle on a row before its search fires by itself.
+// /search-to-add allows 20/min per user and each call spends external API quota,
+// so j/k down a dozen unresolved rows must not spend a dozen searches.
+const AUTOSEARCH_SETTLE_MS = 600;
+
 function StatusPill({ status }) {
   const spec = ROW_STATUS[status] || ROW_STATUS.unresolved;
   return <span className={`rounded px-1.5 py-0.5 text-[11px] font-medium ${spec.cls}`}>{spec.label}</span>;
@@ -124,6 +129,20 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
 
   const counts = summarize(rows);
   const focusedRow = rows[focus];
+  const prefill = focusedRow ? searchTitle(focusedRow.raw_text) : '';
+
+  // Moving to another row re-arms the box for that row: the previous row's
+  // query and results are meaningless here. Keyed on the row's identity rather
+  // than its index, so the first render arms too and a re-seed that changes the
+  // row under the cursor doesn't leave a stale query behind. Render-phase, not
+  // an effect.
+  const searchKey = `${focus}:${focusedRow?.raw_text ?? ''}`;
+  const [armedFor, setArmedFor] = useState(null);
+  if (searchKey !== armedFor) {
+    setArmedFor(searchKey);
+    setSearch(prefill);
+    setSearchResults(null);
+  }
 
   const patchRow = useCallback((index, patch) => {
     setRows(rs => rs.map((r, i) => (i === index ? { ...r, ...patch } : r)));
@@ -397,6 +416,33 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       setBusy(null);
     }
   }
+
+  /**
+   * Search by itself when a row needs it and offers nothing to pick from — the
+   * operator's only moves there are find a match, leave it, or drop it.
+   *
+   * Guarded, because /search-to-add is rate-limited and externally metered:
+   * only unresolved rows, only when the batch returned no candidates, once per
+   * row per session, and only after focus has settled so keyboard navigation
+   * doesn't spend the budget on rows passed through.
+   */
+  const autoSearched = useRef(new Set());
+  const autoRef = useRef(null);
+  useEffect(() => { autoRef.current = { focusedRow, prefill, runSearch, busy, readOnly }; });
+  useEffect(() => {
+    const timer = setTimeout(() => {
+      const api = autoRef.current;
+      if (!api || api.readOnly || api.busy) return;
+      const row = api.focusedRow;
+      if (!row || row.dropped || row.thing_id || row.status === 'pending') return;
+      if (row.candidates?.length) return;
+      const key = `${focus}:${row.raw_text}`;
+      if (!api.prefill || autoSearched.current.has(key)) return;
+      autoSearched.current.add(key);
+      api.runSearch(api.prefill);
+    }, AUTOSEARCH_SETTLE_MS);
+    return () => clearTimeout(timer);
+  }, [focus, rows.length]);
 
   // Keyboard-first: staff review fifty rows at a time. Handlers live in a ref so
   // the listener binds once.

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -205,3 +205,68 @@ describe('builder — the link box says what it will do', () => {
     expect(screen.getByRole('button', { name: /re-point/i })).toBeTruthy();
   });
 });
+
+describe('builder — unresolved rows search themselves', () => {
+  const TWO = [
+    { raw_text: 'Persona (1966) 🇸🇪 8.6/10', thing_id: null, resolution_status: 'unresolved', position: 0 },
+    { raw_text: 'The Hunt (2012)', thing_id: 'movie_the_hunt_2012_aa', resolution_status: 'resolved', position: 1 },
+  ];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+    client.get.mockResolvedValue({ data: { results: [] } });
+  });
+
+  it('pre-fills the box with the cleaned title, not the raw text', () => {
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={TWO} />);
+    expect(screen.getByDisplayValue('Persona')).toBeTruthy();
+  });
+
+  it('runs the search itself once focus settles on an unresolved row', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={TWO} />);
+    expect(client.get).not.toHaveBeenCalled();
+
+    await vi.advanceTimersByTimeAsync(700);
+    await vi.waitFor(() =>
+      expect(client.get).toHaveBeenCalledWith('/search-to-add', {
+        params: { query: 'Persona', type: 'Movie', limit: 10 },
+      }),
+    );
+    vi.useRealTimers();
+  });
+
+  it('does not search a row that already resolved', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // Row 2 is resolved; focusing it should spend nothing.
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={[TWO[1]]} />);
+    await vi.advanceTimersByTimeAsync(1500);
+    expect(client.get).not.toHaveBeenCalled();
+    vi.useRealTimers();
+  });
+
+  it('spends nothing on rows passed through by keyboard', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    const many = Array.from({ length: 6 }, (_, i) => ({
+      raw_text: `Unmatched ${i}`,
+      thing_id: null,
+      resolution_status: 'unresolved',
+      position: i,
+    }));
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={many} />);
+
+    // j j j j — straight past four rows inside the settle window.
+    for (let i = 0; i < 4; i++) {
+      fireEvent.keyDown(window, { key: 'j' });
+      await vi.advanceTimersByTimeAsync(100);
+    }
+    expect(client.get).not.toHaveBeenCalled();
+
+    // …and one search once it settles, for the row actually landed on.
+    await vi.advanceTimersByTimeAsync(700);
+    await vi.waitFor(() => expect(client.get).toHaveBeenCalledTimes(1));
+    expect(client.get.mock.calls[0][1].params.query).toBe('Unmatched 4');
+    vi.useRealTimers();
+  });
+});


### PR DESCRIPTION
On an unresolved row the only moves are find a match, leave it, or drop it. The search box arriving empty — with the title in placeholder text you'd have to retype — is a step that shouldn't exist.

Pre-filled with the cleaned title now, and it runs itself.

## Why auto-run needs guards

`/search-to-add` allows **20/min per user**, and each call spends TMDB/Spotify/Books/Places/Yelp quota. Firing on every focus change means `j`/`k` down a dozen unresolved rows burns the minute's budget in about four seconds — and the row you actually stop on gets the 429.

So it fires only when:

- the row is unresolved, not dropped, not pending
- the batch returned **no candidates**, so there's nothing to pick from already
- it hasn't already run for that row this session
- **focus has settled for 600ms**, so rows passed through cost nothing

One test walks `j` four times inside the settle window and asserts exactly one search fires, for the row actually landed on.

Also keys the box on the row's *identity* rather than its index, so the first render arms it too, and a re-seed that changes the row under the cursor doesn't leave a stale query behind.

127 tests.