### PR TITLE
Point the pitch links at the site that actually serves them

### DIFF
--- a/.env.production
+++ b/.env.production
@@ -1,1 +1,6 @@
 VITE_API_URL=https://listgem-platform-production.up.railway.app
+# Where the pitch preview and invite-aware signup actually live today.
+# #533 documents these links as listgem.com — that is the domain they will
+# move to, not the one serving the app now, and the API only allowlists the
+# origin below for CORS.
+VITE_PUBLIC_SITE_URL=https://listgem-website.netlify.app

--- a/src/pages/concierge/PitchDetailPage.test.jsx
+++ b/src/pages/concierge/PitchDetailPage.test.jsx
@@ -140,8 +140,10 @@ describe('pitch detail — token issuing', () => {
     renderDetail();
     await screen.findByText('A rebuilt list');
     tab('Outreach');
-    expect(screen.getByText('https://listgem.com/pitch/pv_1')).toBeTruthy();
-    expect(screen.getByText('https://listgem.com/signup?invite=inv_1')).toBeTruthy();
+    // Host comes from VITE_PUBLIC_SITE_URL and changes when the public surfaces
+    // move domain; the paths are the contract.
+    expect(screen.getByText(/\/pitch\/pv_1$/)).toBeTruthy();
+    expect(screen.getByText(/\/signup\?invite=inv_1$/)).toBeTruthy();
   });
 });
 

--- a/src/pages/concierge/pitchRules.test.js
+++ b/src/pages/concierge/pitchRules.test.js
@@ -156,8 +156,19 @@ describe('intake validation', () => {
 
 describe('public links', () => {
   it('builds the two links staff actually send', () => {
-    expect(previewUrl('pv_1')).toBe('https://listgem.com/pitch/pv_1');
-    expect(inviteUrl('inv_1')).toBe('https://listgem.com/signup?invite=inv_1');
+    // Asserted by shape, not by host: the public surfaces live on a Netlify
+    // domain today and move to listgem.com later, and a test pinned to either
+    // one fails for the wrong reason when that changes.
+    expect(previewUrl('pv_1')).toMatch(/^https:\/\/[^/]+\/pitch\/pv_1$/);
+    expect(inviteUrl('inv_1')).toMatch(/^https:\/\/[^/]+\/signup\?invite=inv_1$/);
+  });
+
+  it('takes its base from VITE_PUBLIC_SITE_URL', () => {
+    // Getting this wrong is silent: the link loads a real page that reports the
+    // preview as withdrawn, because the API won't allowlist the wrong origin.
+    const base = import.meta.env.VITE_PUBLIC_SITE_URL || 'https://listgem.com';
+    expect(previewUrl('pv_1').startsWith(base)).toBe(true);
+    expect(inviteUrl('inv_1').startsWith(base)).toBe(true);
   });
 
   it('renders nothing without a token', () => {

--- a/src/pages/concierge/pitchRules.ts
+++ b/src/pages/concierge/pitchRules.ts
@@ -222,6 +222,10 @@ export function hasErrors(errors: ErrorMap): boolean {
   return Object.keys(errors).length > 0;
 }
 
+// VITE_PUBLIC_SITE_URL is where the public surfaces are served *today*; the
+// listgem.com default is where they are going. Getting this wrong doesn't fail
+// loudly — the link loads a page that reports the preview as withdrawn, because
+// its API call is blocked by CORS for an origin the API doesn't allowlist.
 const PUBLIC_SITE = String(import.meta.env?.VITE_PUBLIC_SITE_URL || 'https://listgem.com').replace(/\/$/, '');
 
 /** The two links staff actually send. Public, no auth, rate-limited 30/min. */


### PR DESCRIPTION
Generating tokens produced `https://listgem.com/pitch/<token>`, which loads a real page reporting the preview as **withdrawn**. The token was fine — fetched server-side it returns the entire pitch — and so was the pitch.

**The link went to the wrong host.** #533 documents both links as `listgem.com`; that's where they're going, not where the app is served today. It's on `listgem-website.netlify.app`, and the API's `CORS_ORIGIN` allowlists that origin and not `listgem.com`. So the page loaded, its API call was refused, and the page maps any failure to *"no longer available"*.

`VITE_PUBLIC_SITE_URL` now names the origin in use. The `listgem.com` default stays, since that's the destination.

## The failure mode is the point

A wrong base URL here doesn't 404 or throw. It produces a plausible, well-designed page telling the recipient their link has expired. Sent to a real target that's the entire pitch wasted, and nothing on our side records a problem — no error, no log, no failed request. We'd have concluded they never clicked.

## Tests

Link assertions no longer pin a host — they pin the paths, which are the contract, plus one test that the base comes from the env var. A test tied to either domain fails for the wrong reason when the move happens.

128 tests, lint, build green.