### PR TITLE
Refuse to save an item of the wrong type

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -9,6 +9,7 @@ import {
   useSearchToAdd,
 } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
+import { typeMatchesPitch } from './pitchRules';
 import {
   ROW_STATUS,
   applyBatchResults,
@@ -128,6 +129,12 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   rowsRef.current = rows;
 
   const counts = summarize(rows);
+  // Items whose type can never live on this pitch. The API accepts them; the
+  // trigger on list_items rejects them at provisioning, i.e. when the target
+  // clicks the invite. Catch them here, where it costs nothing.
+  const mismatched = rows
+    .map((row, i) => ({ row, i }))
+    .filter(({ row }) => !row.dropped && row.thing_id && !typeMatchesPitch(row.match?.type, thingType));
   const focusedRow = rows[focus];
   const prefill = focusedRow ? searchTitle(focusedRow.raw_text) : '';
 
@@ -305,6 +312,13 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
    * created from a pitch is indistinguishable from one created any other way.
    */
   async function pick(candidate) {
+    if (!typeMatchesPitch(candidate.type, thingType)) {
+      setNote({
+        ok: false,
+        text: `“${candidate.title}” is ${candidate.type || 'an unknown type'}, and this is a ${thingType} pitch. A list can only hold one type, and the mismatch fails when the target claims the draft.`,
+      });
+      return;
+    }
     if (candidate.thing_id) {
       patchRow(focus, { thing_id: candidate.thing_id, match: candidate, status: 'resolved' });
       setSearchResults(null);
@@ -510,6 +524,14 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
           <StatusPill status={row.status} />
           {/* A match at 0.4 and one at 1.0 both read as "Resolved" otherwise —
               and a confident-looking wrong match is the expensive kind. */}
+          {row.thing_id && !typeMatchesPitch(row.match?.type, thingType) && (
+            <span
+              className="rounded bg-red-100 px-1.5 py-0.5 text-[11px] font-medium text-red-700"
+              title={`This pitch is ${thingType}; the match is ${row.match?.type}. The target's claim would fail.`}
+            >
+              wrong type
+            </span>
+          )}
           {row.confidence != null && row.status === 'resolved' && (
             <span
               className={`text-[11px] tabular-nums ${
@@ -564,6 +586,17 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         </div>
       )}
 
+      {mismatched.length > 0 && (
+        <div className="rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800">
+          <span className="font-medium">
+            Row {mismatched.map(m => m.i + 1).join(', ')} {mismatched.length === 1 ? 'is' : 'are'} not {thingType}.
+          </span>{' '}
+          Every item on a list must match the list's type — the database rejects a mismatch when the target
+          claims the draft, so this would fail on them rather than on us. Re-match or drop{' '}
+          {mismatched.length === 1 ? 'it' : 'them'} before saving.
+        </div>
+      )}
+
       {/* Summary */}
       <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500">
         <span className="tabular-nums">
@@ -574,6 +607,9 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         <span className="tabular-nums text-gray-500">{counts.unresolved} unresolved</span>
         {counts.pending > 0 && <span className="tabular-nums text-blue-600">{counts.pending} pending</span>}
         {counts.dropped > 0 && <span className="tabular-nums text-gray-400">{counts.dropped} dropped</span>}
+        {mismatched.length > 0 && (
+          <span className="font-medium text-red-600 tabular-nums">{mismatched.length} wrong type</span>
+        )}
         <div className="ml-auto flex items-center gap-1.5 text-[11px] text-gray-400">
           <span>
             j/k row<Kbd>↑↓</Kbd>
@@ -625,7 +661,16 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
           </Button>
           <div className="ml-auto flex items-center gap-2">
             {dirty && <span className="text-xs text-amber-600">unsaved changes</span>}
-            <Button variant="primary" onClick={save} disabled={!!busy || rows.length === 0}>
+            <Button
+              variant="primary"
+              onClick={save}
+              disabled={!!busy || rows.length === 0 || mismatched.length > 0}
+              title={
+                mismatched.length > 0
+                  ? `Row ${mismatched.map(m => m.i + 1).join(', ')} ${mismatched.length === 1 ? 'is' : 'are'} the wrong type for a ${thingType} pitch`
+                  : undefined
+              }
+            >
               {busy === 'saving' ? 'Saving…' : 'Save items'}
               <Kbd>s</Kbd>
             </Button>

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -270,3 +270,44 @@ describe('builder — unresolved rows search themselves', () => {
     vi.useRealTimers();
   });
 });
+
+describe('builder — an item of the wrong type cannot be saved', () => {
+  // A Movie pitch holding a TVSeries saves fine and then fails at provisioning,
+  // because validate_thing_type_match lives on list_items, not pitch_list_items.
+  // The error surfaces when the target clicks the invite — on them, not us.
+  const POISONED = [
+    {
+      raw_text: 'Persona (1966) 🇸🇪 8.6/10',
+      thing_id: 'tvseries_have_i_got_news_for_you_1990_cf27f995',
+      resolution_status: 'resolved',
+      position: 0,
+      thing_type_actual: 'TVSeries',
+      thing_metadata: { title: 'Have I Got News for You', year: 1990 },
+    },
+  ];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+    client.put.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+  });
+
+  it('flags the row, explains the consequence, and blocks the save', () => {
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={POISONED} />);
+
+    expect(screen.getByText('wrong type')).toBeTruthy();
+    expect(screen.getByText(/Row 1 is not Movie/i)).toBeTruthy();
+    expect(screen.getByText(/rejects a mismatch when the target claims/i)).toBeTruthy();
+    expect(screen.getByRole('button', { name: /save items/i }).disabled).toBe(true);
+    expect(client.put).not.toHaveBeenCalled();
+  });
+
+  it('saves normally when the types agree', () => {
+    const clean = [{ ...POISONED[0], thing_id: 'movie_persona_1966_aa', thing_type_actual: 'Movie' }];
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={clean} />);
+
+    expect(screen.queryByText('wrong type')).toBeNull();
+    expect(screen.getByRole('button', { name: /save items/i }).disabled).toBe(false);
+  });
+});

--- a/src/pages/concierge/pitchRules.test.js
+++ b/src/pages/concierge/pitchRules.test.js
@@ -17,6 +17,7 @@ import {
   offeredTransitions,
   previewUrl,
   tokenIssueBlockedReason,
+  typeMatchesPitch,
 } from './pitchRules';
 
 const pitch = (over = {}) => ({ status: 'draft', can_repitch: false, ...over });
@@ -181,5 +182,30 @@ describe('public links', () => {
     expect(isExpired('2026-08-01T00:00:00Z', now)).toBe(true);
     expect(isExpired('2026-09-01T00:00:00Z', now)).toBe(false);
     expect(isExpired(null, now)).toBe(false);
+  });
+});
+
+describe('typeMatchesPitch (the claim-time landmine)', () => {
+  it('accepts the same type', () => {
+    expect(typeMatchesPitch('Movie', 'Movie')).toBe(true);
+  });
+
+  it('rejects a different type — this is what fails at provisioning', () => {
+    // Real case: "Persona (1966)" resolved to a TVSeries on a Movie pitch. The
+    // pitch API accepted it; validate_thing_type_match RAISEs EXCEPTION on
+    // list_items, so it detonates when the target claims the draft.
+    expect(typeMatchesPitch('TVSeries', 'Movie')).toBe(false);
+    expect(typeMatchesPitch('Book', 'Movie')).toBe(false);
+  });
+
+  it('treats TVShow and TVSeries as interchangeable, as the trigger does', () => {
+    expect(typeMatchesPitch('TVShow', 'TVSeries')).toBe(true);
+    expect(typeMatchesPitch('TVSeries', 'TVShow')).toBe(true);
+  });
+
+  it('stays quiet when either side is unknown', () => {
+    // An unresolved row has no type to contradict; don't invent a problem.
+    expect(typeMatchesPitch(null, 'Movie')).toBe(true);
+    expect(typeMatchesPitch('Movie', undefined)).toBe(true);
   });
 });

--- a/src/pages/concierge/pitchRules.ts
+++ b/src/pages/concierge/pitchRules.ts
@@ -244,6 +244,26 @@ export function isExpired(expiresAt?: string | null, now: number = Date.now()): 
 }
 
 /**
+ * Does an item's type belong on a pitch of this type?
+ *
+ * Every item on a list must match the list's `thing_type`, enforced by the
+ * `validate_thing_type_match` trigger with a RAISE EXCEPTION. That trigger sits
+ * on `list_items`, NOT on `pitch_list_items` — so a mismatched item saves into a
+ * pitch without complaint and detonates at provisioning, which is the moment the
+ * target clicks the invite. The failure lands on them, not on us.
+ *
+ * TVShow/TVSeries are interchangeable, matching the trigger's own exception.
+ */
+export function typeMatchesPitch(itemType?: string | null, pitchType?: string | null): boolean {
+  if (!itemType || !pitchType) return true; // nothing to contradict
+  const a = itemType.trim();
+  const b = pitchType.trim();
+  if (a === b) return true;
+  const tv = new Set(['TVSeries', 'TVShow']);
+  return tv.has(a) && tv.has(b);
+}
+
+/**
  * Offline fallback for the intake select. The live vocabulary is `GET /types`
  * (96 entries, public, no auth) — see `useThingTypes`. This list only appears
  * when that endpoint is unreachable, which is also when POST /pitches is


### PR DESCRIPTION
The first end-to-end preview showed `Persona (1966)` matched to `tvseries_have_i_got_news_for_you_1990` — **a TVSeries on a Movie pitch**. It saved without complaint and rendered on the page a target would see.

## That draft could not have been claimed

Every item on a list must match the list's `thing_type`, enforced by `validate_thing_type_match` with a `RAISE EXCEPTION`. The trigger is on **`list_items`, not `pitch_list_items`** — so nothing checks a pitch until provisioning clones it into a real list, which happens the instant the target clicks the invite.

The transaction fails there. On them, at the one moment the entire play depends on, with no signal to us that anything was wrong.

## The builder now treats a mismatch as unsaveable

- the row carries a red **wrong type** chip naming both types
- a banner names the rows and explains the consequence
- **Save is disabled** while any remain
- picking a mismatched candidate is refused outright, with the reason

Deliberately a block, not a warning. A wrong entry the operator can *see* is a judgement call — the confidence score exists for that. An item that guarantees the claim fails isn't, and the cost lands on someone outside the building.

## Not addressed here

Why "Persona" matched a British panel show at all. That's the matcher, and worth its own report. This addresses the fact that nothing between that answer and the target's browser questioned it.

134 tests, typecheck, lint, build green.