### PR TITLE
Fetch a thing from a link whose id we recognise

### DIFF
--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -493,7 +493,10 @@ export function useThingTypes() {
  */
 export function useSearchToAdd() {
   return useMutation({
-    mutationFn: ({ query, type, limit = 10 }) =>
+    // 25, not 10: the API sorts registry hits first, so a common word fills
+    // every slot with local partial matches and the external result you were
+    // actually looking for never appears.
+    mutationFn: ({ query, type, limit = 25 }) =>
       client.get('/search-to-add', { params: { query, type: type || undefined, limit } }).then(r => r.data),
   });
 }
@@ -513,6 +516,16 @@ export function useSearchToAdd() {
 export function useResolveOrCreate() {
   return useMutation({
     mutationFn: (body) => client.post('/things/resolve-or-create', body).then(r => r.data),
+  });
+}
+
+/**
+ * Poll a crawl started by resolve-or-create's { create: true } path. Returns
+ * `thingId` once `status` is `completed`.
+ */
+export function useCrawlStatus() {
+  return useMutation({
+    mutationFn: (crawlId) => client.get(`/ingestion/crawl-status/${crawlId}`).then(r => r.data),
   });
 }
 

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -5,6 +5,7 @@ import {
   useImportParse,
   usePitchMutations,
   useResolveBatch,
+  useCrawlStatus,
   useResolveOrCreate,
   useSearchToAdd,
 } from '../../api/hooks';
@@ -106,11 +107,17 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   const [searchResults, setSearchResults] = useState(null);
   const [urlInput, setUrlInput] = useState('');
   const [addUrl, setAddUrl] = useState('');
+  // A link whose identifier we read but whose Thing we don't hold. Offering the
+  // crawl explicitly, rather than doing it silently, keeps the "don't mint junk
+  // from a random page" rule while unblocking the case where the identifier is
+  // one the crawler resolves through a source API.
+  const [creatable, setCreatable] = useState(null);
 
   const parse = useImportParse();
   const resolveBatch = useResolveBatch();
   const searchToAdd = useSearchToAdd();
   const resolveOrCreate = useResolveOrCreate();
+  const crawlStatus = useCrawlStatus();
   const { saveItems } = usePitchMutations(pitchId);
 
   // Re-seed when the server's item set changes identity (detail query settles).
@@ -149,6 +156,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     setArmedFor(searchKey);
     setSearch(prefill);
     setSearchResults(null);
+    setCreatable(null);
   }
 
   const patchRow = useCallback((index, patch) => {
@@ -281,6 +289,50 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     }
   }
 
+  /**
+   * Bring in a Thing from a link whose identifier we recognised but don't hold.
+   *
+   * Offered only after a 404 that returned canonical ids — never for an
+   * arbitrary page. For an IMDb or TMDB link the crawler resolves through the
+   * source API (crawlExtraction's imdb.com/title branch), so this produces the
+   * same entry a search would, not a scrape of whatever the page happened to
+   * expose. Creation is asynchronous: the API queues a crawl and hands back an
+   * id to poll.
+   */
+  async function createFromLink({ url, row }) {
+    setBusy('adding');
+    setNote({ ok: true, text: 'Fetching it from the source…' });
+    try {
+      const queued = await resolveOrCreate.mutateAsync({ url, create: true });
+      const crawlId = queued.crawl_id;
+      if (!crawlId) throw new Error('No crawl id returned');
+
+      for (let attempt = 0; attempt < 20; attempt++) {
+        if (cancelled.current) return;
+        await new Promise(r => setTimeout(r, 3000));
+        const status = await crawlStatus.mutateAsync(crawlId);
+        if (status.status === 'completed' && status.thingId) {
+          const res = await resolveOrCreate.mutateAsync({ url });
+          const match = normalizeCandidate({ ...(res.thing || {}), thing_id: res.thing_id || status.thingId });
+          patchRow(row, { thing_id: res.thing_id || status.thingId, match, status: 'resolved' });
+          setCreatable(null);
+          setUrlInput('');
+          setNote({ ok: true, text: `Added “${match?.title || status.thingId}” and attached it to row ${row + 1}.` });
+          return;
+        }
+        if (status.status === 'failed') {
+          setNote({ ok: false, text: `Couldn't fetch that link — ${status.error || 'the crawl failed'}. ${status.suggestion || 'Search by title instead.'}` });
+          return;
+        }
+      }
+      setNote({ ok: false, text: 'Still fetching after a minute. It may finish on its own — search by title, or try the link again shortly.' });
+    } catch (err) {
+      setNote({ ok: false, text: `Couldn't add from that link — ${apiErrorMessage(err)}` });
+    } finally {
+      setBusy(null);
+    }
+  }
+
   async function runSearch(query, { context = '' } = {}) {
     if (!query.trim()) return;
     setBusy('searching');
@@ -393,6 +445,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         // context rides along so the search's own note doesn't erase the fact
         // that the link WAS understood.
         setBusy(null);
+        setCreatable({ url: url.trim(), idText, row: focus });
         await runSearch(searchTitle(focusedRow?.raw_text || ''), {
           context: `Link read${idText ? ` (${idText})` : ''} but not in our registry — `,
         });
@@ -829,6 +882,22 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                   {focusedRow.thing_id ? 'Re-point' : 'Match'}
                 </Button>
               </form>
+              {creatable && creatable.row === focus && (
+                <div className="mt-2 rounded border border-dashed border-gray-300 p-2">
+                  <div className="text-[11px] text-gray-500">
+                    We read {creatable.idText || 'the identifier'} from that link but don't hold it yet. Fetching
+                    it from the source adds it to the registry, same as picking a search result.
+                  </div>
+                  <Button
+                    size="sm"
+                    className="mt-1.5"
+                    disabled={!!busy}
+                    onClick={() => createFromLink(creatable)}
+                  >
+                    {busy === 'adding' ? 'Fetching…' : 'Add it from this link'}
+                  </Button>
+                </div>
+              )}
               <TextInput
                 className="mt-2"
                 value={focusedRow.note || ''}

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -230,8 +230,10 @@ describe('builder — unresolved rows search themselves', () => {
 
     await vi.advanceTimersByTimeAsync(700);
     await vi.waitFor(() =>
+      // 25, not 10: registry hits sort first, so a common word fills every slot
+      // with local partial matches and the external result never appears.
       expect(client.get).toHaveBeenCalledWith('/search-to-add', {
-        params: { query: 'Persona', type: 'Movie', limit: 10 },
+        params: { query: 'Persona', type: 'Movie', limit: 25 },
       }),
     );
     vi.useRealTimers();
@@ -309,5 +311,66 @@ describe('builder — an item of the wrong type cannot be saved', () => {
 
     expect(screen.queryByText('wrong type')).toBeNull();
     expect(screen.getByRole('button', { name: /save items/i }).disabled).toBe(false);
+  });
+});
+
+describe('builder — a link we recognise but do not hold', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+    client.get.mockResolvedValue({ data: { results: [] } });
+  });
+
+  it('offers to fetch it, polls the crawl, and attaches the result', async () => {
+    vi.useFakeTimers({ shouldAdvanceTime: true });
+    // First call: identify-only, 404 with the id we read. Second: create.
+    client.post
+      .mockRejectedValueOnce({ response: { status: 404, data: { canonical_ids: { imdb_id: 'tt0060827' } } } })
+      .mockResolvedValueOnce({ data: { status: 'queued', crawl_id: 'crawl_1' } })
+      .mockResolvedValueOnce({
+        data: { thing_id: 'movie_persona_1966_zz', created: true, thing: { title: 'Persona', type: 'Movie', year: 1966 } },
+      });
+    client.get.mockImplementation(url =>
+      url === '/ingestion/crawl-status/crawl_1'
+        ? Promise.resolve({ data: { status: 'completed', thingId: 'movie_persona_1966_zz' } })
+        : Promise.resolve({ data: { results: [] } }),
+    );
+
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={ITEMS} />);
+    fireEvent.change(screen.getByPlaceholderText(/Match row 1 using a link/i), {
+      target: { value: 'https://www.imdb.com/title/tt0060827/' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^match$/i }));
+
+    // The offer names what was read, so it reads as a recognised link rather
+    // than a guess at an arbitrary page.
+    const offer = await screen.findByRole('button', { name: /add it from this link/i });
+    // The id appears twice — in the note and in the offer. The offer's copy is
+    // what says the link was recognised rather than guessed at.
+    expect(screen.getByText(/We read imdb_id tt0060827 from that link/i)).toBeTruthy();
+
+    fireEvent.click(offer);
+    await vi.advanceTimersByTimeAsync(3500);
+
+    expect(await screen.findByText(/Added .*Persona.* and attached it to row 1/i)).toBeTruthy();
+    expect(client.post).toHaveBeenCalledWith('/things/resolve-or-create', {
+      url: 'https://www.imdb.com/title/tt0060827/',
+      create: true,
+    });
+    vi.useRealTimers();
+  });
+
+  it('does not offer a crawl for a link carrying no identifier', async () => {
+    client.post.mockRejectedValue({ response: { status: 422, data: { error: 'No canonical id in that URL' } } });
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={ITEMS} />);
+    fireEvent.change(screen.getByPlaceholderText(/Match row 1 using a link/i), {
+      target: { value: 'https://example.com/a-blog-post' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /^match$/i }));
+
+    expect(await screen.findByText(/No identifier in that link/i)).toBeTruthy();
+    // Crawling an arbitrary page mints an entry from whatever it happened to
+    // expose; that stays unavailable.
+    expect(screen.queryByRole('button', { name: /add it from this link/i })).toBeNull();
   });
 });


### PR DESCRIPTION
Two failures from one attempt: searching **Persona** returned exactly ten results with the 1966 film absent, and the IMDb link for it offered nothing to do.

## The ten was the limit

`/search-to-add` sorts registry hits first, so a common word fills every slot with local partial matches and the external result you need never appears. Raised to **25** for the builder's searches.

## The link offered nothing because I'd over-applied a rule

I ruled crawl-and-create out wholesale, taking the backend's reasoning at face value: *an entry minted from a page's metadata is permanently thin.* That's true of an arbitrary page and **false of the one link type staff will actually paste** — `crawlExtraction` matches `imdb.com/title/`, extracts the `tt` id, and resolves it through TMDB. Same source API as a search, same quality of entry.

The offer is now scoped to exactly that distinction:

| Response | Meaning | Offer |
|---|---|---|
| **404 + `canonical_ids`** | we read an identifier we understand, we don't hold it | **Add it from this link** |
| **422** | no identifier in the link | nothing — this *is* the case the rule was written for |

The offer names the id it read (`We read imdb_id tt0060827 from that link…`), so it reads as recognition rather than a guess at a random page.

Creation is asynchronous: queues the crawl, polls `crawl-status` for up to a minute, attaches the resulting `thing_id`. A failed crawl reports the API's own message and suggestion.

136 tests, including one asserting that an unrecognised link is offered no crawl.