### PR TITLE
The pitch's type governs every resolve, not the row's

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -266,7 +266,6 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         match,
         note: '',
         dropped: false,
-        inferred_type: match?.type || null,
         confidence: null,
         reason: null,
       };
@@ -337,7 +336,9 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     if (!query.trim()) return;
     setBusy('searching');
     try {
-      const type = focusedRow?.inferred_type || thingType;
+      // The pitch's type, always — see toBatchPayload. A row's current match
+      // must never constrain the search intended to replace it.
+      const type = thingType;
       const results = normalizeSearchResults(await searchToAdd.mutateAsync({ query: query.trim(), type }));
       setSearchResults(results);
       const sources = [...new Set(results.map(r => r.source).filter(Boolean))].join(', ');
@@ -905,7 +906,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                 placeholder="Note for this row (internal)"
               />
               <div className="mt-2 text-[11px] text-gray-400">
-                Resolving as <span className="font-medium text-gray-500">{focusedRow.inferred_type || thingType}</span>
+                Resolving as <span className="font-medium text-gray-500">{thingType}</span>
                 {focusedRow.reason && <> · server said <span className="text-gray-500">{focusedRow.reason}</span></>}
                 {focusedRow.confidence != null && (
                   <>

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -374,3 +374,37 @@ describe('builder — a link we recognise but do not hold', () => {
     expect(screen.queryByRole('button', { name: /add it from this link/i })).toBeNull();
   });
 });
+
+describe('builder — a wrong match must not steer the search that fixes it', () => {
+  // Reported: searching Persona on a Movie pitch returned twenty TVSeries
+  // (Persona 4 the Animation, Persona 5 the Animation…). The row had mismatched
+  // to a TVSeries, the row's type won over the pitch's, and the search queried
+  // TMDB's TV index — so the film could not appear at all.
+  const MISMATCHED = [
+    {
+      raw_text: 'Persona (1966) 🇸🇪 8.6/10',
+      thing_id: 'tvseries_have_i_got_news_for_you_1990_cf27f995',
+      resolution_status: 'resolved',
+      position: 0,
+      thing_type_actual: 'TVSeries',
+      thing_metadata: { title: 'Have I Got News for You', year: 1990 },
+    },
+  ];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+    client.get.mockResolvedValue({ data: { results: [] } });
+  });
+
+  it('searches as the pitch type, not as the wrong match', async () => {
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={MISMATCHED} />);
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    await vi.waitFor(() =>
+      expect(client.get).toHaveBeenCalledWith('/search-to-add', {
+        params: { query: 'Persona', type: 'Movie', limit: 25 },
+      }),
+    );
+  });
+});

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -86,20 +86,30 @@ describe('the shapes prod actually returns', () => {
     expect(parsed[1].inferred_type).toBe('Movie');
   });
 
-  it('builds /resolve/batch candidates with a type on every row', () => {
-    // `type` is required per candidate and the parser often sends none, so the
-    // pitch's thing_type has to fill in or the whole batch 400s.
+  it('sends the pitch type on every candidate, never a row-derived one', () => {
+    // A list holds one type, so there is no legitimate row-level variation —
+    // and a row that matched the wrong thing carries that thing's type. Letting
+    // that win constrained the search meant to correct it: a Movie pitch whose
+    // row had mismatched to a TVSeries searched TMDB's TV index and returned
+    // twenty TV results, none of them the film.
     const rows = rowsFromParsed([
       { position: 0, raw_text: 'The Matrix', inferred_type: null },
       { position: 1, raw_text: 'Slow Horses', inferred_type: 'TVSeries' },
     ]);
     expect(toBatchPayload(rows, [0, 1], 'Movie')).toEqual([
       { type: 'Movie', title: 'The Matrix' },
-      { type: 'TVSeries', title: 'Slow Horses' },
+      { type: 'Movie', title: 'Slow Horses' },
     ]);
     // …and the year rides as its own field when the text carries one.
     const dated = rowsFromParsed([{ position: 0, raw_text: 'Arrival (2016)', inferred_type: null }]);
     expect(toBatchPayload(dated, [0], 'Movie')).toEqual([{ type: 'Movie', title: 'Arrival', year: 2016 }]);
+  });
+
+  it('a saved row that matched the wrong type does not carry it forward', () => {
+    const rows = rowsFromItems([
+      { raw_text: 'Persona (1966)', thing_id: 'tvseries_wrong', resolution_status: 'resolved', thing_type_actual: 'TVSeries' },
+    ]);
+    expect(toBatchPayload(rows, [0], 'Movie')).toEqual([{ type: 'Movie', title: 'Persona', year: 1966 }]);
   });
 });
 

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -59,8 +59,6 @@ export interface BuilderRow {
   match: Candidate | null;
   note: string;
   dropped: boolean;
-  /** From /imports/parse; falls back to the pitch's thing_type when null. */
-  inferred_type: string | null;
   confidence: number | null;
   reason: string | null;
 }
@@ -325,8 +323,14 @@ export function extractYear(rawText: string): number | null {
 
 /**
  * `candidates` for POST /resolve/batch. `type` is required per candidate, and
- * the builder has no per-row type of its own — it uses the parser's
- * `inferred_type` when there is one and the pitch's `thing_type` otherwise.
+ * it is ALWAYS the pitch's own type.
+ *
+ * Never a type derived from a row's current match. A list holds exactly one
+ * type, so there is no legitimate row-level variation — and a row that matched
+ * the wrong thing carries that thing's type, which would then constrain the
+ * search meant to correct it. That happened: a Movie pitch whose row had
+ * mismatched to a TVSeries searched TMDB's TV index and returned twenty
+ * TV results, none of them the film.
  */
 export function toBatchPayload(
   rows: BuilderRow[],
@@ -337,7 +341,7 @@ export function toBatchPayload(
     const raw = rows[rowIndex].raw_text;
     const year = extractYear(raw);
     return {
-      type: rows[rowIndex].inferred_type || fallbackType,
+      type: fallbackType,
       title: searchTitle(raw),
       ...(year ? { year } : {}),
     };
@@ -423,7 +427,6 @@ export function rowsFromParsed(parsed: ParsedCandidate[]): BuilderRow[] {
     match: null,
     note: '',
     dropped: false,
-    inferred_type: p.inferred_type ?? null,
     confidence: null,
     reason: null,
   }));
@@ -470,7 +473,6 @@ export function rowsFromItems(items: unknown): BuilderRow[] {
         match: match?.thing_id || match?.title !== '(untitled)' ? match : null,
         note: typeof it.note === 'string' ? it.note : '',
         dropped: false,
-        inferred_type: firstString(it.thing_type_actual),
         confidence: null,
         reason: null,
       };


### PR DESCRIPTION
Searching **Persona** on a Movie pitch returned twenty TVSeries — *Persona 4 the Animation*, *Persona 5 the Animation*, *Persona -trinity soul-*. The 1966 film couldn't appear, because the search never asked for a film.

`rowsFromItems` set a row's `inferred_type` from the saved item's `thing_type_actual`, and the search preferred that over the pitch's `thing_type`. Row 3 had mismatched to a TVSeries → the row said TVSeries → the search queried TMDB's **TV** index.

**The wrong match was steering the search whose only job was to replace it.** And it compounds: each wrong match makes the next search for that row worse.

A list holds exactly one type — now enforced on save (#33). So there is no legitimate row-level type at all, and `inferred_type` is removed from `BuilderRow` rather than left as a field nobody should read. The pitch's `thing_type` goes to `/resolve/batch` and `/search-to-add` for every row, always.

The parser's `inferred_type` stays in the parse response type, since it's part of that contract — the builder just no longer carries it onto rows.

138 tests, including one asserting a row holding a TVSeries match still batches as the pitch's `Movie`.