### PR TITLE
Say what a pick attached; label the two result lists

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -373,9 +373,18 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       return;
     }
     if (candidate.thing_id) {
+      const replaced = focusedRow?.match?.title;
       patchRow(focus, { thing_id: candidate.thing_id, match: candidate, status: 'resolved' });
       setSearchResults(null);
       setSearch('');
+      // Say what was attached. Picking used to be silent, so a mis-click looked
+      // identical to a correct one until you re-read the table.
+      setNote({
+        ok: true,
+        text: `Row ${focus + 1} → “${candidate.title}”${candidate.year ? ` (${candidate.year})` : ''}${
+          replaced && replaced !== candidate.title ? `, replacing “${replaced}”` : ''
+        }.`,
+      });
       return;
     }
     if (!candidate.source_id) {
@@ -815,7 +824,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
               <div className="text-[11px] uppercase tracking-wider text-gray-400">Candidates</div>
               {focusedRow.candidates.map((c, i) => (
                 <CandidateRow
-                  key={c.thing_id || i}
+                  key={`${i}-${c.thing_id || c.title}`}
                   candidate={c}
                   chosen={c.thing_id && c.thing_id === focusedRow.thing_id}
                   busy={busy === 'adding'}
@@ -845,10 +854,13 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
               </form>
               {searchResults && (
                 <div className="mt-2 space-y-1">
+                  <div className="text-[11px] uppercase tracking-wider text-gray-400">
+                    Search results{searchResults.length ? ` (${searchResults.length})` : ''}
+                  </div>
                   {searchResults.length === 0 && <div className="text-xs text-gray-400">No candidates.</div>}
                   {searchResults.map((c, i) => (
                     <CandidateRow
-                    key={c.thing_id || `${c.source}-${c.source_id}` || i}
+                    key={`${i}-${c.thing_id || c.source_id || c.title}`}
                     candidate={c}
                     chosen={false}
                     busy={busy === 'adding'}

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -408,3 +408,45 @@ describe('builder — a wrong match must not steer the search that fixes it', ()
     );
   });
 });
+
+describe('builder — picking says what it attached', () => {
+  // A registry pick used to be silent: click, and nothing told you which of
+  // twenty near-identical results landed. A mis-click looked exactly like a
+  // correct one until you re-read the table.
+  const RESULTS = {
+    results: [
+      { thing_id: 'movie_persona3_4_2016_zz', title: 'Persona3 the Movie #4 Winter of Rebirth', type: 'Movie', year: 2016, source: 'local', in_registry: true },
+      { thing_id: 'movie_persona_1966_aa', title: 'Persona', type: 'Movie', year: 1966, source: 'local', in_registry: true },
+    ],
+  };
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+    client.get.mockResolvedValue({ data: RESULTS });
+  });
+
+  it('names the title and year it attached, and what it replaced', async () => {
+    const wrong = [
+      {
+        raw_text: 'Persona (1966) 🇸🇪 8.6/10',
+        thing_id: 'movie_persona3_4_2016_zz',
+        resolution_status: 'resolved',
+        position: 0,
+        thing_type_actual: 'Movie',
+        thing_metadata: { title: 'Persona3 the Movie #4 Winter of Rebirth', year: 2016 },
+      },
+    ];
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={wrong} />);
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+
+    // The results list is labelled, so it can't be confused with the
+    // Candidates list stacked above it.
+    await screen.findByText(/Search results \(2\)/i);
+    fireEvent.click(await screen.findByText('Persona'));
+
+    expect(
+      await screen.findByText(/Row 1 → “Persona” \(1966\), replacing “Persona3 the Movie #4 Winter of Rebirth”/i),
+    ).toBeTruthy();
+  });
+});


### PR DESCRIPTION
Picking the 1966 *Persona* attached **Persona3 the Movie #4 Winter of Rebirth** — the entry one row above it. Three things made that possible and undetectable:

**1. Attaching a registry hit was silent.** The external path announces what it added; the registry path patched the row and said nothing. A wrong pick looked identical to a right one until you re-read the table. It now names the title, the year, and what it replaced:

> Row 3 → "Persona" (1966), replacing "Persona3 the Movie #4 Winter of Rebirth".

**2. Two stacked lists, one unlabelled.** The editor shows *Candidates* from the resolve, then search results underneath with no heading. Twenty entries called "Persona" across two lists is a mis-click waiting to happen. The second list now has a heading and a count.

**3. Keys could collide.** `c.thing_id || \`${c.source}-${c.source_id}\`` yields the same key for any two external results missing a `source_id`, and duplicate keys let React bind a handler to the wrong element — which produces exactly this symptom. Both lists now key on index plus identifier, which cannot collide whatever the API returns.

I can't prove which it was. The first two are defects regardless, and the third makes the class impossible.

139 tests.