### PR TITLE
Guard the save operation, not the save button

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -289,6 +289,13 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     try {
       const data = await resolveOrCreate.mutateAsync({ url: url.trim() });
       const match = normalizeCandidate({ ...(data.thing || {}), thing_id: data.thing_id });
+      if (!typeMatchesPitch(match?.type, thingType)) {
+        setNote({
+          ok: false,
+          text: `That link is ${match?.type || 'another type'}, and this is a ${thingType} pitch. Nothing added.`,
+        });
+        return;
+      }
       const row = {
         raw_text: match?.title || url.trim(),
         thing_id: data.thing_id,
@@ -344,6 +351,14 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         if (status.status === 'completed' && status.thingId) {
           const res = await resolveOrCreate.mutateAsync({ url });
           const match = normalizeCandidate({ ...(res.thing || {}), thing_id: res.thing_id || status.thingId });
+          if (!typeMatchesPitch(match?.type, thingType)) {
+            setNote({
+              ok: false,
+              text: `That link turned out to be ${match?.type || 'another type'} — added to the registry, but not attached to a ${thingType} pitch.`,
+            });
+            setCreatable(null);
+            return;
+          }
           patchRow(row, { thing_id: res.thing_id || status.thingId, match, status: 'resolved' });
           setCreatable(null);
           setUrlInput('');
@@ -461,6 +476,13 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     try {
       const data = await resolveOrCreate.mutateAsync({ url: url.trim() });
       const match = normalizeCandidate({ ...(data.thing || {}), thing_id: data.thing_id });
+      if (!typeMatchesPitch(match?.type, thingType)) {
+        setNote({
+          ok: false,
+          text: `That link is ${match?.type || 'another type'}, and this is a ${thingType} pitch. Not attached.`,
+        });
+        return;
+      }
       const replaced = focusedRow?.match?.title;
       patchRow(focus, { thing_id: data.thing_id, match, status: 'resolved' });
       setUrlInput('');
@@ -510,6 +532,19 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   }
 
   async function save() {
+    // Guard the operation, not the button. Save is reachable from the `s`
+    // shortcut too, which is how a TVSeries reached a Movie pitch after the
+    // disabled button had already refused it: the keypath never asked.
+    // The API validates nothing here, so this is the only check there is.
+    if (mismatched.length > 0) {
+      setNote({
+        ok: false,
+        text: `Not saved — row ${mismatched.map(m => m.i + 1).join(', ')} ${
+          mismatched.length === 1 ? 'is' : 'are'
+        } not ${thingType}. The target's claim would fail on it.`,
+      });
+      return;
+    }
     setBusy('saving');
     setNote(null);
     try {

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -493,3 +493,46 @@ describe('builder — a wrong-type match is never attached in the first place', 
     expect(screen.getByRole('button', { name: /save items/i }).disabled).toBe(false);
   });
 });
+
+describe('builder — the save guard is on the operation, not the button', () => {
+  const POISONED = [
+    {
+      raw_text: 'Persona (1966) 🇸🇪 8.6/10',
+      thing_id: 'tvseries_hignfy_1990',
+      resolution_status: 'resolved',
+      position: 0,
+      thing_type_actual: 'TVSeries',
+      thing_metadata: { title: 'Have I Got News for You', year: 1990 },
+    },
+  ];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+    client.put.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+    client.put.mockResolvedValue({ data: { success: true, item_count: 1 } });
+  });
+
+  it('refuses the `s` shortcut too, which is how the mismatch got saved', () => {
+    // The button was disabled and the keypath called save() directly. The API
+    // validates nothing on PUT items, so the UI check is the only one there is
+    // — which makes "guard the button" not a guard at all.
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={POISONED} />);
+    expect(screen.getByRole('button', { name: /save items/i }).disabled).toBe(true);
+
+    fireEvent.keyDown(window, { key: 's' });
+
+    expect(client.put).not.toHaveBeenCalled();
+    expect(screen.getByText(/Not saved — row 1 is not Movie/i)).toBeTruthy();
+  });
+
+  it('still saves by shortcut when nothing is mismatched', async () => {
+    const clean = [{ ...POISONED[0], thing_id: 'movie_persona_1966_aa', thing_type_actual: 'Movie', thing_metadata: { title: 'Persona', year: 1966 } }];
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={clean} />);
+
+    fireEvent.keyDown(window, { key: 's' });
+
+    await vi.waitFor(() => expect(client.put).toHaveBeenCalledWith('/pitches/p_1/items', expect.anything()));
+  });
+});


### PR DESCRIPTION
Row 3 kept returning as a TVSeries on a Movie pitch after being fixed. The screen explained it: **"Saved 11 item(s)"** sat directly above the block.

**The save had succeeded.** The disabled button refused it; the `s` shortcut called `save()` straight through. So the mismatch reached `PUT /pitches/:id/items`, which validates nothing, and the next refetch pulled it back in. Every round of fixing was undone by a keystroke.

`save()` now checks and refuses whatever calls it. The button stays disabled as the visible signal, but it is no longer the mechanism.

**Three other paths attached with no type check at all** — `resolveFromUrl`, `addRowFromUrl`, `createFromLink`. A link resolving to a TVSeries would have reached a Movie pitch by the same route. All three now check.

## The shape of the bug

The check lived where the action was *presented* rather than where it was *performed*, so every alternative route to the same action skipped it. The keyboard shortcut predates the guard, which is exactly how it got missed — and it's the same reason the API-side validation matters as defence in depth, since the portal is currently the only thing standing between a mismatched item and a failed claim.

142 tests, including that `s` refuses and that a clean set still saves by shortcut.