### PR TITLE
A lagging refetch must not undo the operator

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -128,12 +128,32 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   const crawlStatus = useCrawlStatus();
   const { saveItems } = usePitchMutations(pitchId);
 
-  // Re-seed when the server's item set changes identity (detail query settles).
+  /**
+   * Adopt the server's item set when it arrives — but never over the operator's
+   * work, and never straight after our own write.
+   *
+   * Saving invalidates the pitch query, and GET /pitches/:id reads from a
+   * replica. The refetch can therefore return the rows as they were BEFORE the
+   * write, and adopting those silently reverted the edit that had just been
+   * saved. Save again and the stale copy goes back to the server: a fix that
+   * undoes itself, which is exactly what a wrong match kept doing.
+   */
   const [seenItems, setSeenItems] = useState(items);
+  const skipNextSeed = useRef(false);
+  const [staleWarning, setStaleWarning] = useState(false);
   if (items !== seenItems) {
     setSeenItems(items);
-    setRows(rowsFromItems(items));
-    setDirty(false);
+    if (skipNextSeed.current) {
+      // Our own write echoing back, possibly from a lagging replica. We know
+      // what we sent; the screen already shows it.
+      skipNextSeed.current = false;
+    } else if (dirty) {
+      // Someone or something changed the stored set while this build was in
+      // progress. Local work wins, but say so rather than silently diverging.
+      setStaleWarning(true);
+    } else {
+      setRows(rowsFromItems(items));
+    }
   }
 
   const cancelled = useRef(false);
@@ -550,6 +570,10 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     try {
       const payload = toItemsPayload(rows);
       const data = await saveItems.mutateAsync({ items: payload });
+      // The invalidation this triggers may read a replica that hasn't caught
+      // up; don't let that overwrite what we just wrote.
+      skipNextSeed.current = true;
+      setStaleWarning(false);
       setDirty(false);
       setRows(rs => rs.filter(r => !r.dropped));
       setNote({ ok: true, text: `Saved ${data?.item_count ?? payload.length} item(s).` });
@@ -712,6 +736,13 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       {note && (
         <div className={`rounded p-2 text-xs ${note.ok ? 'bg-green-50 text-green-700' : 'bg-amber-50 text-amber-800'}`}>
           {note.text}
+        </div>
+      )}
+
+      {staleWarning && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+          The stored item set changed while you were working. Your unsaved changes are still here and will
+          win when you save — reload first if you'd rather start from the stored copy.
         </div>
       )}
 

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -1,3 +1,4 @@
+import { useState } from 'react';
 import { beforeEach, describe, expect, it, vi } from 'vitest';
 import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
@@ -534,5 +535,55 @@ describe('builder — the save guard is on the operation, not the button', () =>
     fireEvent.keyDown(window, { key: 's' });
 
     await vi.waitFor(() => expect(client.put).toHaveBeenCalledWith('/pitches/p_1/items', expect.anything()));
+  });
+});
+
+describe('builder — a lagging refetch must not undo the operator', () => {
+  // Saving invalidates the pitch query, and GET /pitches/:id reads a replica.
+  // The refetch can return the rows as they were BEFORE the write; adopting
+  // those reverted the edit that had just been saved, and saving again wrote
+  // the stale copy back. A fix that undoes itself.
+  const STALE = [{
+    raw_text: 'Persona (1966)',
+    thing_id: 'tvseries_hignfy_1990',
+    resolution_status: 'resolved',
+    position: 0,
+    thing_type_actual: 'TVSeries',
+    thing_metadata: { title: 'Have I Got News for You', year: 1990 },
+  }];
+
+  function Harness() {
+    // Mirrors PitchDetailPage: `items` changes identity when the query refetches.
+    const [items, setItems] = useState(STALE);
+    return (
+      <>
+        <button onClick={() => setItems([...STALE])}>refetch stale</button>
+        <PitchBuilder pitchId="p_1" thingType="Movie" items={items} />
+      </>
+    );
+  }
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.put.mockReset();
+    client.get.mockResolvedValue({
+      data: { results: [{ thing_id: 'movie_persona_1966_aa', title: 'Persona', type: 'Movie', year: 1966, source: 'local', in_registry: true }] },
+    });
+    client.put.mockResolvedValue({ data: { success: true, item_count: 1 } });
+  });
+
+  it('keeps the picked match when the server echoes the old rows back', async () => {
+    renderWithProviders(<Harness />);
+    fireEvent.click(screen.getByRole('button', { name: /^search$/i }));
+    fireEvent.click(await screen.findByText('Persona'));
+    await screen.findByText(/Row 1 → “Persona”/);
+
+    // The replica hands back the pre-write rows.
+    fireEvent.click(screen.getByRole('button', { name: /refetch stale/i }));
+
+    // The edit survives, and the wrong-type block does not return.
+    expect(screen.queryByText('wrong type')).toBeNull();
+    expect(screen.getByRole('button', { name: /save items/i }).disabled).toBe(false);
+    expect(screen.getByText(/stored item set changed while you were working/i)).toBeTruthy();
   });
 });


### PR DESCRIPTION
Row 3 kept reverting after being fixed and saved, and the server kept holding the old value — even though the UI reported **"Saved 11 item(s)"**.

Saving invalidates the pitch query. `GET /pitches/:id` reads from a **replica**, so the refetch can return the rows as they were *before* the write. The builder adopted them, discarding the edit that had just been saved. Save again and the stale copy went back to the server.

**A fix that undoes itself** — which is why four rounds of guards never made the row stick.

## Three cases now, where there was one

| Situation | Behaviour |
|---|---|
| Our own write echoing back | Keep local — we know what we sent |
| Unsaved work in progress | Keep local, and say the stored copy moved |
| Neither | Adopt the server's set, as before |

The middle case matters well beyond replica lag: **any** refetch mid-build would silently discard whatever the operator had adjudicated. Fifty rows of work could vanish on a background refetch with no message at all.

## How it hid

Every guard I added was correct, and none could work, because the state they inspected was being replaced underneath them. The symptom pointed at the matcher, then at types, then at the save path. It was none of those.

143 tests, including that a stale echo leaves the picked match in place.