### PR TITLE
Show the API's own error; guard a held invite

### DIFF
--- a/src/api/errors.js
+++ b/src/api/errors.js
@@ -4,18 +4,41 @@
  * The concierge endpoints answer 409 on an illegal status transition with an
  * `allowed: [...]` list — surface it verbatim rather than "something failed",
  * so staff can see the machine disagreed and what it would accept instead.
+ *
+ * Some also answer with a machine code in `error` and the human sentence in
+ * `message` (TYPE_MISMATCH, for one). Leading with the code buries the part
+ * worth reading, so a code-shaped `error` steps aside for its message.
+ *
+ * And where the body names the offending items, their positions are turned
+ * into the row numbers shown on screen — 0-based on the wire, 1-based in the
+ * table, which is exactly the sort of mismatch an operator shouldn't have to
+ * do in their head.
  */
+const CODE = /^[A-Z][A-Z0-9_]+$/;
+
 export function apiErrorMessage(err) {
   const data = err?.response?.data;
   const status = err?.response?.status;
-  const base = data?.error || data?.message || err?.message || 'Request failed';
-  // Several endpoints put the headline in `error` and the actionable part in
-  // `message` — the last-admin 409 being the one that matters most.
-  const detail = data?.error && data?.message && data.message !== data.error ? ` ${data.message}` : '';
+  const code = typeof data?.error === 'string' && CODE.test(data.error) ? data.error : null;
+  const headline = code ? data.message || data.error : data?.error || data?.message || err?.message || 'Request failed';
+  // Keep both when they say different things and neither is a bare code.
+  const detail =
+    !code && data?.error && data?.message && data.message !== data.error ? ` ${data.message}` : '';
   const allowed = Array.isArray(data?.allowed) && data.allowed.length
     ? ` Allowed from here: ${data.allowed.join(', ')}.`
     : '';
-  return `${status ? `${status} · ` : ''}${base}${detail}${allowed}`;
+  const rows = itemRows(err);
+  const where = rows.length ? ` Row ${rows.join(', ')}.` : '';
+  return `${status ? `${status} · ` : ''}${headline}${detail}${allowed}${where}`;
+}
+
+/** Row numbers (1-based) for items an error body called out by position. */
+export function itemRows(err) {
+  const items = err?.response?.data?.items;
+  if (!Array.isArray(items)) return [];
+  return items
+    .map(i => (typeof i?.position === 'number' ? i.position + 1 : null))
+    .filter(n => n !== null);
 }
 
 export function allowedFrom(err) {

--- a/src/api/errors.test.js
+++ b/src/api/errors.test.js
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest';
+import { apiErrorMessage, itemRows } from './errors';
+
+const err = (status, data) => ({ response: { status, data } });
+
+describe('apiErrorMessage', () => {
+  it('leads with the sentence, not the machine code', () => {
+    // PUT /pitches/:id/items answers { error: 'TYPE_MISMATCH', message, items }.
+    // "400 · TYPE_MISMATCH" tells an operator nothing they can act on.
+    const msg = apiErrorMessage(
+      err(400, {
+        error: 'TYPE_MISMATCH',
+        message: '1 item(s) do not match the pitch type "Movie". A pitch containing them could not be claimed.',
+        expected_type: 'Movie',
+        items: [{ position: 2, thing_id: 'tvseries_x', raw_text: 'Persona (1966)' }],
+      }),
+    );
+    expect(msg).toContain('do not match the pitch type "Movie"');
+    expect(msg).not.toContain('TYPE_MISMATCH');
+  });
+
+  it('translates 0-based positions into the row numbers on screen', () => {
+    const e = err(400, { error: 'TYPE_MISMATCH', message: 'nope', items: [{ position: 2 }, { position: 5 }] });
+    expect(apiErrorMessage(e)).toContain('Row 3, 6.');
+    expect(itemRows(e)).toEqual([3, 6]);
+  });
+
+  it('keeps a human `error` as the headline', () => {
+    expect(apiErrorMessage(err(404, { error: 'Pitch not found' }))).toBe('404 · Pitch not found');
+  });
+
+  it('still appends `allowed` on an illegal transition', () => {
+    const msg = apiErrorMessage(err(409, { error: 'Illegal transition', allowed: ['archived'] }));
+    expect(msg).toContain('Allowed from here: archived.');
+  });
+
+  it('still appends a differing message alongside a human error', () => {
+    const msg = apiErrorMessage(err(409, { error: 'Cannot remove the last admin', message: 'Grant another admin first.' }));
+    expect(msg).toContain('Cannot remove the last admin');
+    expect(msg).toContain('Grant another admin first.');
+  });
+
+  it('falls back when there is no body at all', () => {
+    expect(apiErrorMessage(new Error('Network Error'))).toBe('Network Error');
+    expect(itemRows(undefined)).toEqual([]);
+  });
+});

--- a/src/pages/concierge/PitchDetailPage.jsx
+++ b/src/pages/concierge/PitchDetailPage.jsx
@@ -212,7 +212,7 @@ export default function PitchDetailPage() {
 
       {tab === 'outreach' && (
         <div className="space-y-4">
-          <TokensPanel pitch={pitch} />
+          <TokensPanel pitch={pitch} events={events} />
 
           <div className="rounded-lg border border-red-200 bg-white p-4">
             <h3 className="text-sm font-semibold text-gray-900">Takedown</h3>

--- a/src/pages/concierge/PitchDetailPage.test.jsx
+++ b/src/pages/concierge/PitchDetailPage.test.jsx
@@ -161,3 +161,71 @@ describe('pitch detail — status transitions', () => {
     expect(offered).toEqual(['Archived']);
   });
 });
+
+describe('pitch detail — an expired invite may be a deliberate hold', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+  });
+
+  // Expiring an invite is how a pitch gets paused, and the reason lives in the
+  // audit trail rather than in any field the portal can read. Re-issuing
+  // replaces both tokens and lifts the hold silently.
+  const HELD = {
+    ...BASE,
+    status: 'pitched',
+    invite_token: 'inv_1',
+    preview_token: 'pv_1',
+    invite_expires_at: '2026-08-01T00:00:00Z',
+    invite_used_at: null,
+  };
+
+  function serveHeld() {
+    client.get.mockImplementation(url =>
+      url === '/pitches/p_1'
+        ? Promise.resolve({
+            data: {
+              pitch: HELD,
+              items: [],
+              events: [
+                { event_type: 'tokens_issued', detail: 'invite + preview issued', actor: 'gtm@listgem.com', created_at: '2026-07-20T10:00:00Z' },
+                { event_type: 'status_changed', detail: 'invite expired to hold the pitch pending legal review', actor: 'gtm@listgem.com', created_at: '2026-08-01T09:00:00Z' },
+              ],
+            },
+          })
+        : Promise.reject(new Error('not mocked')),
+    );
+  }
+
+  it('warns, shows the last audit line, and takes two presses to re-issue', async () => {
+    serveHeld();
+    renderDetail();
+    await screen.findByText('A rebuilt list');
+    tab('Outreach');
+
+    expect(screen.getByText(/expired while the pitch is still pitched/i)).toBeTruthy();
+    // The reason is a tab away otherwise, and that's the tab nobody opens.
+    expect(screen.getByText(/hold the pitch pending legal review/i)).toBeTruthy();
+
+    const button = screen.getByRole('button', { name: /re-issue tokens…/i });
+    fireEvent.click(button);
+    expect(client.post).not.toHaveBeenCalled();
+    expect(screen.getByText(/Press again to re-issue and lift the hold/i)).toBeTruthy();
+
+    fireEvent.click(screen.getByRole('button', { name: /^re-issue tokens$/i }));
+    await vi.waitFor(() => expect(client.post).toHaveBeenCalledWith('/pitches/p_1/tokens'));
+  });
+
+  it('does not nag when the invite expired on a pitch nobody is chasing', async () => {
+    client.get.mockImplementation(url =>
+      url === '/pitches/p_1'
+        ? Promise.resolve({ data: { pitch: { ...HELD, status: 'declined' }, items: [], events: [] } })
+        : Promise.reject(new Error('not mocked')),
+    );
+    renderDetail();
+    await screen.findByText('A rebuilt list');
+    tab('Outreach');
+
+    expect(screen.queryByText(/expired while the pitch is still/i)).toBeNull();
+  });
+});

--- a/src/pages/concierge/TokensPanel.jsx
+++ b/src/pages/concierge/TokensPanel.jsx
@@ -44,16 +44,30 @@ function fmt(iso) {
  * link can claim the draft, which is why identity is confirmed after the claim
  * and never here.
  */
-export default function TokensPanel({ pitch }) {
+export default function TokensPanel({ pitch, events }) {
   const { issueTokens } = usePitchMutations(pitch.pitch_id);
   const [note, setNote] = useState(null);
   const [issued, setIssued] = useState(null);
+  const [confirmReissue, setConfirmReissue] = useState(false);
 
   const blocked = tokenIssueBlockedReason(pitch);
   const invite = issued?.invite_token || pitch.invite_token;
   const preview = issued?.preview_token || pitch.preview_token;
   const expiresAt = issued?.invite_expires_at || pitch.invite_expires_at;
   const expired = isExpired(expiresAt);
+
+  /**
+   * An expired invite on a pitch still in play may be deliberate: expiring it
+   * is how a pitch gets paused, and the reason lives in the audit trail rather
+   than in any field we could read. Re-issuing replaces both tokens and undoes
+   * that hold silently, so the expiry earns a second step and the last audit
+   * line is shown here rather than a tab away.
+   */
+  const inPlay = pitch.status === 'pitched' || pitch.status === 'accepted';
+  const mayBeHeld = expired && inPlay && !pitch.invite_used_at;
+  const lastEvent = Array.isArray(events) && events.length
+    ? [...events].sort((a, b) => new Date(b.created_at || b.at || 0) - new Date(a.created_at || a.at || 0))[0]
+    : null;
 
   async function issue() {
     setNote(null);
@@ -78,17 +92,41 @@ export default function TokensPanel({ pitch }) {
         <div className="mb-3 flex items-center gap-3">
           <h3 className="text-sm font-semibold text-gray-900">Preview + invite links</h3>
           <Button
-            variant="primary"
+            variant={mayBeHeld && !confirmReissue ? 'secondary' : 'primary'}
             size="sm"
             className="ml-auto"
             disabled={!canIssueTokens(pitch) || issueTokens.isPending}
-            onClick={issue}
+            onClick={() => (mayBeHeld && !confirmReissue ? setConfirmReissue(true) : issue())}
           >
-            {issueTokens.isPending ? 'Issuing…' : invite ? 'Re-issue tokens' : 'Generate tokens'}
+            {issueTokens.isPending
+              ? 'Issuing…'
+              : mayBeHeld && !confirmReissue
+                ? 'Re-issue tokens…'
+                : invite
+                  ? 'Re-issue tokens'
+                  : 'Generate tokens'}
           </Button>
         </div>
 
         {blocked && <div className="mb-3 rounded bg-gray-50 p-2 text-xs text-gray-600">{blocked}</div>}
+
+        {mayBeHeld && (
+          <div className="mb-3 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+            <span className="font-medium">This invite has expired while the pitch is still {pitch.status}.</span>{' '}
+            That can be deliberate — expiring the invite is how a pitch gets held. Re-issuing replaces both
+            tokens and lifts the hold.
+            {lastEvent && (
+              <div className="mt-1 text-amber-700">
+                Last audit entry: <span className="font-medium">{lastEvent.event_type || lastEvent.type}</span>
+                {lastEvent.detail ? ` — ${lastEvent.detail}` : ''}
+                {lastEvent.actor ? ` (${lastEvent.actor})` : ''}
+              </div>
+            )}
+            {confirmReissue && (
+              <div className="mt-1.5 font-medium">Press again to re-issue and lift the hold.</div>
+            )}
+          </div>
+        )}
 
         <div className="space-y-2">
           <CopyRow label="Preview" url={previewUrl(preview)} hint="Read-only page for the target. Public, no auth." />


### PR DESCRIPTION
Two items from the backend's note.

## 1. TYPE_MISMATCH, surfaced properly

`PUT /pitches/:id/items` now answers `400 TYPE_MISMATCH` with `expected_type` and an `items[]` naming each offending position (platform#553). `apiErrorMessage` led with whatever sat in `error`, so an operator would have read **"400 · TYPE_MISMATCH"** and none of the sentence explaining it.

A code-shaped `error` now steps aside for its `message`, and **positions are translated into the row numbers on screen** — 0-based on the wire, 1-based in the table, which isn't arithmetic anyone should do in their head mid-build. `Unknown thing_id` gets the same treatment for free.

## 2. A held invite can no longer be undone blindly

Expiring an invite is how a pitch gets paused, and the reason lives in the audit trail rather than in any field the portal can read — there's no event type for a hold, so this can't be detected structurally. It can only be made hard to undo by accident.

An expired invite on a **pitched** or **accepted** pitch now:

- says so explicitly
- shows the most recent audit entry **inline**, rather than a tab away — that tab being the one nobody opens
- takes two presses to re-issue

Declined and archived pitches don't nag; nobody is holding those.

151 tests.

Not in this PR: the dark-mode placeholder on the preview page — that's `listgem-website` and gets its own change.