### PR TITLE
An expired invite is a lapsed TTL, not a hold

### DIFF
--- a/src/pages/concierge/PitchDetailPage.jsx
+++ b/src/pages/concierge/PitchDetailPage.jsx
@@ -212,7 +212,7 @@ export default function PitchDetailPage() {
 
       {tab === 'outreach' && (
         <div className="space-y-4">
-          <TokensPanel pitch={pitch} events={events} />
+          <TokensPanel pitch={pitch} />
 
           <div className="rounded-lg border border-red-200 bg-white p-4">
             <h3 className="text-sm font-semibold text-gray-900">Takedown</h3>

--- a/src/pages/concierge/PitchDetailPage.test.jsx
+++ b/src/pages/concierge/PitchDetailPage.test.jsx
@@ -162,16 +162,17 @@ describe('pitch detail — status transitions', () => {
   });
 });
 
-describe('pitch detail — an expired invite may be a deliberate hold', () => {
+describe('pitch detail — an expired invite is a lapsed TTL', () => {
   beforeEach(() => {
     client.get.mockReset();
     client.post.mockReset();
   });
 
-  // Expiring an invite is how a pitch gets paused, and the reason lives in the
-  // audit trail rather than in any field the portal can read. Re-issuing
-  // replaces both tokens and lifts the hold silently.
-  const HELD = {
+  // There is no such thing as a held invite. Only two paths write
+  // invite_expires_at — issuing tokens sets the TTL, takedown NULLs it — and
+  // nothing sets it into the past. So an expired invite on a pitch still in
+  // play means the 30 days lapsed unanswered, and re-issuing is correct.
+  const LAPSED = {
     ...BASE,
     status: 'pitched',
     invite_token: 'inv_1',
@@ -180,52 +181,33 @@ describe('pitch detail — an expired invite may be a deliberate hold', () => {
     invite_used_at: null,
   };
 
-  function serveHeld() {
+  function serve(pitch) {
     client.get.mockImplementation(url =>
       url === '/pitches/p_1'
-        ? Promise.resolve({
-            data: {
-              pitch: HELD,
-              items: [],
-              events: [
-                { event_type: 'tokens_issued', detail: 'invite + preview issued', actor: 'gtm@listgem.com', created_at: '2026-07-20T10:00:00Z' },
-                { event_type: 'status_changed', detail: 'invite expired to hold the pitch pending legal review', actor: 'gtm@listgem.com', created_at: '2026-08-01T09:00:00Z' },
-              ],
-            },
-          })
+        ? Promise.resolve({ data: { pitch, items: [], events: [] } })
         : Promise.reject(new Error('not mocked')),
     );
   }
 
-  it('warns, shows the last audit line, and takes two presses to re-issue', async () => {
-    serveHeld();
+  it('says the TTL lapsed and re-issues in one press', async () => {
+    serve(LAPSED);
     renderDetail();
     await screen.findByText('A rebuilt list');
     tab('Outreach');
 
-    expect(screen.getByText(/expired while the pitch is still pitched/i)).toBeTruthy();
-    // The reason is a tab away otherwise, and that's the tab nobody opens.
-    expect(screen.getByText(/hold the pitch pending legal review/i)).toBeTruthy();
+    expect(screen.getByText(/30-day invite has lapsed/i)).toBeTruthy();
+    // Warn about the consequence, don't obstruct the right action.
+    expect(screen.getByText(/any link already sent stops working/i)).toBeTruthy();
 
-    const button = screen.getByRole('button', { name: /re-issue tokens…/i });
-    fireEvent.click(button);
-    expect(client.post).not.toHaveBeenCalled();
-    expect(screen.getByText(/Press again to re-issue and lift the hold/i)).toBeTruthy();
-
-    fireEvent.click(screen.getByRole('button', { name: /^re-issue tokens$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /re-issue tokens/i }));
     await vi.waitFor(() => expect(client.post).toHaveBeenCalledWith('/pitches/p_1/tokens'));
   });
 
-  it('does not nag when the invite expired on a pitch nobody is chasing', async () => {
-    client.get.mockImplementation(url =>
-      url === '/pitches/p_1'
-        ? Promise.resolve({ data: { pitch: { ...HELD, status: 'declined' }, items: [], events: [] } })
-        : Promise.reject(new Error('not mocked')),
-    );
+  it('stays quiet on a pitch nobody is chasing', async () => {
+    serve({ ...LAPSED, status: 'declined' });
     renderDetail();
     await screen.findByText('A rebuilt list');
     tab('Outreach');
-
-    expect(screen.queryByText(/expired while the pitch is still/i)).toBeNull();
+    expect(screen.queryByText(/30-day invite has lapsed/i)).toBeNull();
   });
 });

--- a/src/pages/concierge/TokensPanel.jsx
+++ b/src/pages/concierge/TokensPanel.jsx
@@ -44,11 +44,10 @@ function fmt(iso) {
  * link can claim the draft, which is why identity is confirmed after the claim
  * and never here.
  */
-export default function TokensPanel({ pitch, events }) {
+export default function TokensPanel({ pitch }) {
   const { issueTokens } = usePitchMutations(pitch.pitch_id);
   const [note, setNote] = useState(null);
   const [issued, setIssued] = useState(null);
-  const [confirmReissue, setConfirmReissue] = useState(false);
 
   const blocked = tokenIssueBlockedReason(pitch);
   const invite = issued?.invite_token || pitch.invite_token;
@@ -57,17 +56,16 @@ export default function TokensPanel({ pitch, events }) {
   const expired = isExpired(expiresAt);
 
   /**
-   * An expired invite on a pitch still in play may be deliberate: expiring it
-   * is how a pitch gets paused, and the reason lives in the audit trail rather
-   than in any field we could read. Re-issuing replaces both tokens and undoes
-   * that hold silently, so the expiry earns a second step and the last audit
-   * line is shown here rather than a tab away.
+   * An expired invite on a pitch still in play means one thing: the 30-day TTL
+   * lapsed on a pitch nobody answered. Only two paths write invite_expires_at —
+   * issuing tokens sets the TTL, takedown NULLs it — and nothing sets it into
+   * the past, so there is no such thing as a deliberately held invite.
+   *
+   * Re-issuing is therefore the right move, and this says so rather than
+   * standing in its way.
    */
   const inPlay = pitch.status === 'pitched' || pitch.status === 'accepted';
-  const mayBeHeld = expired && inPlay && !pitch.invite_used_at;
-  const lastEvent = Array.isArray(events) && events.length
-    ? [...events].sort((a, b) => new Date(b.created_at || b.at || 0) - new Date(a.created_at || a.at || 0))[0]
-    : null;
+  const lapsed = expired && inPlay && !pitch.invite_used_at;
 
   async function issue() {
     setNote(null);
@@ -92,39 +90,23 @@ export default function TokensPanel({ pitch, events }) {
         <div className="mb-3 flex items-center gap-3">
           <h3 className="text-sm font-semibold text-gray-900">Preview + invite links</h3>
           <Button
-            variant={mayBeHeld && !confirmReissue ? 'secondary' : 'primary'}
+            variant="primary"
             size="sm"
             className="ml-auto"
             disabled={!canIssueTokens(pitch) || issueTokens.isPending}
-            onClick={() => (mayBeHeld && !confirmReissue ? setConfirmReissue(true) : issue())}
+            onClick={issue}
           >
-            {issueTokens.isPending
-              ? 'Issuing…'
-              : mayBeHeld && !confirmReissue
-                ? 'Re-issue tokens…'
-                : invite
-                  ? 'Re-issue tokens'
-                  : 'Generate tokens'}
+            {issueTokens.isPending ? 'Issuing…' : invite ? 'Re-issue tokens' : 'Generate tokens'}
           </Button>
         </div>
 
         {blocked && <div className="mb-3 rounded bg-gray-50 p-2 text-xs text-gray-600">{blocked}</div>}
 
-        {mayBeHeld && (
+        {lapsed && (
           <div className="mb-3 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
-            <span className="font-medium">This invite has expired while the pitch is still {pitch.status}.</span>{' '}
-            That can be deliberate — expiring the invite is how a pitch gets held. Re-issuing replaces both
-            tokens and lifts the hold.
-            {lastEvent && (
-              <div className="mt-1 text-amber-700">
-                Last audit entry: <span className="font-medium">{lastEvent.event_type || lastEvent.type}</span>
-                {lastEvent.detail ? ` — ${lastEvent.detail}` : ''}
-                {lastEvent.actor ? ` (${lastEvent.actor})` : ''}
-              </div>
-            )}
-            {confirmReissue && (
-              <div className="mt-1.5 font-medium">Press again to re-issue and lift the hold.</div>
-            )}
+            <span className="font-medium">The 30-day invite has lapsed.</span> Re-issue to send a fresh link —
+            that's the normal next step on a pitch nobody has answered. It replaces both tokens, so any link
+            already sent stops working.
           </div>
         )}
 


### PR DESCRIPTION
Reverts the premise of the guard I shipped an hour ago in #40.

I was told a pitch had been paused by expiring its invite, with the reason in the history panel, and built a two-press confirmation around it. A reviewer on listgem-website#104 checked the code instead and found no such mechanism. **Verified here independently:**

- exactly two paths write `invite_expires_at` — `pitches.js:431` sets the TTL when issuing tokens, `:617` NULLs it on takedown
- expiry is judged purely by `invite_expires_at < NOW()`
- no event type records a hold; there's no endpoint to create one

So an expired invite on a pitch still in play means **thirty days lapsed on a pitch nobody answered**, where re-issuing is exactly right.

My guard put a barrier in front of the correct action and sent operators looking for an audit entry nothing writes — the same defect that review had just corrected in the playbook, reimplemented in the UI.

Now it states the lapse, names the one real consequence — re-issuing replaces both tokens, so links already sent stop working — and re-issues in one press.

## The lesson

I've spent this week refusing to take claims about system behaviour on trust, and then took one on trust because it arrived from the team that owns the code. It was checkable in two greps.

151 tests.