### PR TITLE
Correct why search comes before a link

### DIFF
--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -509,9 +509,12 @@ export function useSearchToAdd() {
  *   { source_type, source_id, type }  a federated-search hit — synchronous
  *   { url }                           identify only; 404/422 when we don't hold it
  *
- * URL mode deliberately does not create: a Thing minted from a pasted link's OG
- * tags is a permanent low-quality registry entry, and searching routes through
- * the source APIs instead and produces a better one.
+ * URL mode does not create by default. Not because a crawl produces a thin
+ * entry — it runs the same enrichment pipeline a normal add does — but because
+ * a page gives whatever the page said, while a source catalogue gives the
+ * canonical record. Crawling an Open Library page produced "Yüzüklerin Efendisi
+ * by J.R.R. Tolkien": the right book, the Turkish edition, because that is what
+ * was served. Search first, link as the fallback.
  */
 export function useResolveOrCreate() {
   return useMutation({

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -350,11 +350,17 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
    * Bring in a Thing from a link whose identifier we recognised but don't hold.
    *
    * Offered only after a 404 that returned canonical ids — never for an
-   * arbitrary page. For an IMDb or TMDB link the crawler resolves through the
-   * source API (crawlExtraction's imdb.com/title branch), so this produces the
-   * same entry a search would, not a scrape of whatever the page happened to
-   * expose. Creation is asynchronous: the API queues a crawl and hands back an
-   * id to poll.
+   * arbitrary page.
+   *
+   * The reason isn't entry quality: a crawl runs the same enrichment pipeline a
+   * normal add does. It's that a page yields whatever the page said, while a
+   * source catalogue yields the canonical record — an Open Library crawl
+   * produced "Yüzüklerin Efendisi by J.R.R. Tolkien", the right book in Turkish,
+   * because that was the edition served. A recognised identifier doesn't have
+   * that problem: it resolves through the source API either way.
+   *
+   * Creation is asynchronous: the API queues a crawl and hands back an id to
+   * poll.
    */
   async function createFromLink({ url, row }) {
     setBusy('adding');
@@ -484,10 +490,10 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   }
 
   /**
-   * Identify a Thing from a pasted link. Deliberately identify-only: the API
-   * will not mint a Thing from a link's metadata, because one built from thin
-   * OG tags is a permanent low-quality registry entry, and searching routes
-   * through the source APIs and produces a better one. A miss says so.
+   * Identify a Thing from a pasted link. Identify-only by default: a link tells
+   * us what page someone was looking at, not which canonical record they meant,
+   * and search resolves that better. A miss says so, and offers the crawl only
+   * when the link carried an identifier we recognise.
    */
   async function resolveFromUrl(url) {
     if (!url.trim()) return;


### PR DESCRIPTION
listgem-website#104 corrected the claim these comments were built on. An entry created from a link is **not** "permanently thin" — the crawl runs the same enrichment pipeline a normal add does. That reasoning was the backend's, offered in good faith, and repeated by me in three places without checking it.

The real argument is better and narrower: **a page yields whatever the page said, a source catalogue yields the canonical record.** Crawling an Open Library page produced *"Yüzüklerin Efendisi by J.R.R. Tolkien"* — the right book, the Turkish edition, because that's what was served. On a list we're about to show its supposed author, the edition matters.

That leaves the behaviour intact and better justified: search first, link as fallback, crawl offered only for a link carrying a recognised identifier — since an identifier resolves through the source API either way and doesn't have the page problem.

Comments only, no behaviour change. 151 tests.