### PR TITLE
Report which of the three send outcomes happened

### DIFF
--- a/src/pages/emails/EmailsPage.jsx
+++ b/src/pages/emails/EmailsPage.jsx
@@ -60,7 +60,23 @@ export default function EmailsPage() {
     setSendResult(null);
     try {
       const res = await client.post('/admin/email/send-test', { template: selected, data: fields, to: testEmail });
-      setSendResult({ ok: true, message: `Sent to ${res.data.to}` });
+      const { delivery, provider_id: providerId, to } = res.data;
+      // The API distinguishes three outcomes (#561). "Sent" used to cover all
+      // of them, so a send that never happened read as a success — and a
+      // genuine send that landed in spam was indistinguishable from one that
+      // was silently dropped.
+      if (delivery === 'skipped_no_api_key') {
+        setSendResult({ ok: false, message: 'Not sent — the server has no RESEND_API_KEY configured.' });
+      } else if (delivery === 'skipped_dev_mode') {
+        setSendResult({ ok: false, message: 'Not sent — the server is not running in production mode; it logged the message instead.' });
+      } else {
+        // Deliberately not "delivered": Resend has accepted it, and bounces and
+        // spam placement happen after that.
+        setSendResult({
+          ok: true,
+          message: `Accepted by Resend for ${to}${providerId ? ` · id ${providerId}` : ''}. Check spam if it doesn't arrive — a [TEST] subject is itself a spam signal.`,
+        });
+      }
     } catch (err) {
       // The API answers { error: 'Send failed', message: <the actual cause> }.
       // Showing only `error` reduced every failure to a label — "Send failed",

--- a/src/pages/emails/EmailsPage.test.jsx
+++ b/src/pages/emails/EmailsPage.test.jsx
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest';
+import { fireEvent, screen } from '@testing-library/react';
+import { renderWithProviders } from '../../test/utils';
+import client from '../../api/client';
+import EmailsPage from './EmailsPage';
+
+vi.mock('../../api/client', () => ({
+  default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
+}));
+
+const TEMPLATES = {
+  templates: [{ key: 'welcome', label: 'Welcome', fields: { username: 'New User', loginUrl: 'https://x/' } }],
+};
+
+async function open() {
+  renderWithProviders(<EmailsPage />);
+  await screen.findByText('Welcome');
+  fireEvent.change(screen.getByPlaceholderText(/recipient@/i), { target: { value: 'tim@example.com' } });
+}
+
+describe('email send-test outcomes', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+    client.get.mockResolvedValue({ data: TEMPLATES });
+  });
+
+  const send = () => fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+  it('reports acceptance without claiming delivery', async () => {
+    client.post.mockResolvedValue({ data: { sent: true, delivery: 'queued', provider_id: 're_123', to: 'tim@example.com' } });
+    await open();
+    send();
+    // "Sent" overclaims: Resend accepting a message says nothing about bounces
+    // or spam placement, which is exactly where the last one went.
+    expect(await screen.findByText(/Accepted by Resend for tim@example.com · id re_123/)).toBeTruthy();
+  });
+
+  it('does not call a skipped send a success', async () => {
+    client.post.mockResolvedValue({ data: { sent: false, delivery: 'skipped_no_api_key', provider_id: null, to: 'tim@example.com' } });
+    await open();
+    send();
+    expect(await screen.findByText(/Not sent — the server has no RESEND_API_KEY/i)).toBeTruthy();
+  });
+
+  it('names dev mode rather than reporting success', async () => {
+    client.post.mockResolvedValue({ data: { sent: false, delivery: 'skipped_dev_mode', provider_id: null, to: 'tim@example.com' } });
+    await open();
+    send();
+    expect(await screen.findByText(/not running in production mode/i)).toBeTruthy();
+  });
+
+  it('distinguishes a template failure from a send failure', async () => {
+    client.post.mockRejectedValue({
+      response: { status: 500, data: { error: 'Template render failed', template: 'welcome', message: "Cannot read properties of undefined (reading 'map')" } },
+    });
+    await open();
+    send();
+    expect(await screen.findByText(/Template render failed.*reading 'map'/s)).toBeTruthy();
+  });
+});


### PR DESCRIPTION
platform#561 shipped: `send-test` now answers `delivery` as `queued` / `skipped_no_api_key` / `skipped_dev_mode`, with a `provider_id`, and separates *Template render failed* from *Send failed*.

The portal said **"Sent to X"** for all of it — actively wrong for the two skipped cases, and unhelpfully vague for the real one. A send that never happened looked identical to a send that landed in spam, which is the confusion that cost an hour yesterday.

| delivery | message |
|---|---|
| `queued` | Accepted by Resend for `<to>` · id `<provider_id>` |
| `skipped_no_api_key` | Not sent — no `RESEND_API_KEY` configured |
| `skipped_dev_mode` | Not sent — server not in production; it logged instead |

Deliberately **"accepted"**, not "sent" or "delivered". Resend taking a message says nothing about bounces or spam placement — and the last one went to spam — so the wording stops where the knowledge stops, and notes that a `[TEST]` subject is itself a spam signal.

The `provider_id` is the point: it's the handle for finding a message in Resend when someone asks where it went, and the portal had no way to get it before.

155 tests — four on this page, which had none.