### PR TITLE
An unreported outcome is not a success

### DIFF
--- a/src/pages/emails/EmailsPage.jsx
+++ b/src/pages/emails/EmailsPage.jsx
@@ -69,12 +69,21 @@ export default function EmailsPage() {
         setSendResult({ ok: false, message: 'Not sent — the server has no RESEND_API_KEY configured.' });
       } else if (delivery === 'skipped_dev_mode') {
         setSendResult({ ok: false, message: 'Not sent — the server is not running in production mode; it logged the message instead.' });
-      } else {
+      } else if (delivery === 'queued') {
         // Deliberately not "delivered": Resend has accepted it, and bounces and
         // spam placement happen after that.
         setSendResult({
           ok: true,
           message: `Accepted by Resend for ${to}${providerId ? ` · id ${providerId}` : ''}. Check spam if it doesn't arrive — a [TEST] subject is itself a spam signal.`,
+        });
+      } else {
+        // No `delivery` at all. Reading that as success is the exact mistake
+        // this page just stopped making: an API that doesn't say what happened
+        // has not told us that anything did. Older builds answered a bare
+        // { sent: true }, so this is what a pre-#561 server looks like.
+        setSendResult({
+          unknown: true,
+          message: `The request was accepted for ${to}, but the API didn't report an outcome — no delivery state and no provider id. This server predates the change that reports them, so whether it sent is unknown. Check the inbox, and the Resend dashboard.`,
         });
       }
     } catch (err) {
@@ -172,7 +181,11 @@ export default function EmailsPage() {
                 </button>
               </div>
               {sendResult && (
-                <p className={`mt-2 text-xs ${sendResult.ok ? 'text-green-600' : 'text-red-600'}`}>
+                <p
+                  className={`mt-2 text-xs ${
+                    sendResult.unknown ? 'text-amber-700' : sendResult.ok ? 'text-green-600' : 'text-red-600'
+                  }`}
+                >
                   {sendResult.message}
                 </p>
               )}

--- a/src/pages/emails/EmailsPage.test.jsx
+++ b/src/pages/emails/EmailsPage.test.jsx
@@ -59,3 +59,26 @@ describe('email send-test outcomes', () => {
     expect(await screen.findByText(/Template render failed.*reading 'map'/s)).toBeTruthy();
   });
 });
+
+describe('email send-test — an unreported outcome is not a success', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+    client.post.mockReset();
+    client.get.mockResolvedValue({ data: TEMPLATES });
+  });
+
+  it('says so when the API reports no delivery state', async () => {
+    // A pre-#561 server answers a bare { sent: true }. Treating a missing
+    // `delivery` as queued reintroduces the problem this page just fixed:
+    // claiming a send happened on no evidence that it did.
+    client.post.mockResolvedValue({ data: { sent: true, to: 'tim@example.com' } });
+    renderWithProviders(<EmailsPage />);
+    await screen.findByText('Welcome');
+    fireEvent.change(screen.getByPlaceholderText(/recipient@/i), { target: { value: 'tim@example.com' } });
+    fireEvent.click(screen.getByRole('button', { name: /^send$/i }));
+
+    const msg = await screen.findByText(/didn't report an outcome/i);
+    expect(msg).toBeTruthy();
+    expect(msg.className).toMatch(/amber/);
+  });
+});


### PR DESCRIPTION
A test send reported *"Accepted by Resend for …"* with **no provider id**. That id is the whole point of platform#561, so its absence means the response carried no `delivery` field either — and my client read a missing field as `queued`.

Which is precisely the mistake this page had just stopped making. The endpoint used to answer a bare `{ sent: true }` for sends that never happened; I replaced that with three named outcomes and then wrote a fallback treating *"the API said nothing"* as the good one.

A missing `delivery` now says what it is: the request was accepted, the API reported no outcome, whether it sent is **unknown**. Amber rather than green — a third state, because two weren't enough to express it.

It also gives the portal a way to notice it's talking to a pre-#561 server, which is the likely situation right now: the fix is on `main` and the deployed worker has 79,981 seconds of uptime.

156 tests.