### PR TITLE
Say when the parser clipped the paste

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -17,6 +17,7 @@ import {
   batchResults,
   chunkForBatch,
   normalizeCandidate,
+  normalizeParseOutcome,
   normalizeParsed,
   normalizeSearchResults,
   searchTitle,
@@ -268,8 +269,18 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     setBusy('parsing');
     setNote(null);
     let parsed = [];
+    let clipped = null;
     try {
-      parsed = normalizeParsed(await parse.mutateAsync(paste));
+      const outcome = normalizeParseOutcome(await parse.mutateAsync(paste));
+      parsed = outcome.candidates;
+      // The parser caps input and reports when it clipped. Losing that meant a
+      // long paste quietly lost its tail: a plausible list of rows, and no sign
+      // the last twenty never arrived.
+      if (outcome.truncated) {
+        clipped = outcome.maxInputChars
+          ? `Only the first ${outcome.maxInputChars.toLocaleString()} characters were parsed — the rest of your paste was cut. Split it and paste the remainder.`
+          : 'The parser cut your input short. Split it and paste the remainder.';
+      }
     } catch (err) {
       // No parser reachable — fall back to one row per non-empty line so the
       // operator can still build and resolve by hand.
@@ -288,6 +299,8 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     setBusy(null);
     const startAt = replace ? 0 : rows.length;
     await resolveIndices(fresh.map((_, i) => startAt + i), { source: next });
+    // After the resolve, so it isn't overwritten by the resolve's own note.
+    if (clipped) setNote({ ok: false, text: clipped });
   }
 
   /**

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -4,6 +4,7 @@ import {
   applyBatchResults,
   batchResults,
   chunkForBatch,
+  normalizeParseOutcome,
   normalizeParsed,
   normalizeResolution,
   normalizeSearchResults,
@@ -391,5 +392,36 @@ describe('searchTitle — list decoration wrecks the match', () => {
     expect(toBatchPayload(rows, [0], 'Movie')).toEqual([{ type: 'Movie', title: 'Persona', year: 1966 }]);
     // The operator still sees what they pasted, and so does the target.
     expect(rows[0].raw_text).toBe('Persona (1966) 🇸🇪 8.6/10');
+  });
+});
+
+describe('normalizeParseOutcome — a clipped paste must not look complete', () => {
+  it('reports truncation and the cap', () => {
+    // /imports/parse caps input at max_input_chars and sets truncated when it
+    // clips. Dropping that left the operator with a plausible list of rows and
+    // no sign the tail never arrived.
+    const out = normalizeParseOutcome({
+      success: true,
+      candidates: [{ position: 0, raw_text: 'The Exorcist (1973)', inferred_type: null }],
+      candidate_count: 1,
+      method: 'structured',
+      truncated: true,
+      max_input_chars: 20000,
+    });
+    expect(out.truncated).toBe(true);
+    expect(out.maxInputChars).toBe(20000);
+    expect(out.method).toBe('structured');
+    expect(out.candidates).toHaveLength(1);
+  });
+
+  it('is quiet when nothing was clipped', () => {
+    const out = normalizeParseOutcome({ candidates: [], truncated: false, max_input_chars: 20000 });
+    expect(out.truncated).toBe(false);
+  });
+
+  it('treats a missing flag as not truncated, not as unknown', () => {
+    // A parser that says nothing has not said it clipped; don't invent a warning.
+    expect(normalizeParseOutcome({ candidates: [] }).truncated).toBe(false);
+    expect(normalizeParseOutcome(null).truncated).toBe(false);
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -79,6 +79,21 @@ export interface ParsedCandidate {
   inferred_type: string | null;
 }
 
+/**
+ * What the parse step reports beyond the candidates themselves.
+ *
+ * `/imports/parse` caps input at `max_input_chars` (20,000 in production) and
+ * sets `truncated` when it clips. Dropping that meant a long paste silently
+ * lost its tail: the operator sees a plausible list of rows and no indication
+ * that the last twenty never arrived.
+ */
+export interface ParseOutcome {
+  candidates: ParsedCandidate[];
+  truncated: boolean;
+  maxInputChars: number | null;
+  method: string | null;
+}
+
 /** POST /resolve and each element of /resolve/batch's `candidates`. */
 export interface ResolveRequest {
   type: string;
@@ -250,6 +265,7 @@ export function normalizeResolution(raw: unknown): Resolution {
 }
 
 /** Ordered candidates out of POST /imports/parse — `{ position, raw_text }`. */
+/** The candidates alone, for callers that don't care how the parse went. */
 export function normalizeParsed(data: unknown): ParsedCandidate[] {
   const list = isObject(data) && Array.isArray(data.items)
     ? data.items
@@ -268,6 +284,17 @@ export function normalizeParsed(data: unknown): ParsedCandidate[] {
     })
     .filter(c => c.raw_text.trim())
     .sort((a, b) => a.position - b.position);
+}
+
+/** The candidates plus whether the input was clipped on the way in. */
+export function normalizeParseOutcome(data: unknown): ParseOutcome {
+  const d = isObject(data) ? data : {};
+  return {
+    candidates: normalizeParsed(data),
+    truncated: d.truncated === true,
+    maxInputChars: typeof d.max_input_chars === 'number' ? d.max_input_chars : null,
+    method: firstString(d.method),
+  };
 }
 
 /**


### PR DESCRIPTION
`/imports/parse` caps input at `max_input_chars` — 20,000 in production — and sets `truncated` when it clips. The builder read only the candidates and discarded both flags.

So a long paste produced a plausible list of rows **with no sign the tail never arrived**. An operator pasting a fifty-item article would adjudicate thirty rows carefully and never learn about the other twenty.

`normalizeParseOutcome` now returns the candidates alongside `truncated`, `maxInputChars` and `method`, and the builder reports the clip *after* the resolve finishes so the resolve's own note doesn't bury it:

> Only the first 20,000 characters were parsed — the rest of your paste was cut. Split it and paste the remainder.

Found while setting up the forty-row test, and worth fixing before running it: the test would otherwise have been measuring a path that quietly drops half its input.

159 tests.