### PR TITLE
Copy a diagnostics dump from the builder

### DIFF
--- a/src/api/client.js
+++ b/src/api/client.js
@@ -1,4 +1,5 @@
 import axios from 'axios';
+import { recordError, recordResponse } from './requestLog';
 
 const API_URL = import.meta.env.DEV ? '' : import.meta.env.VITE_API_URL || 'http://localhost:3000';
 
@@ -7,19 +8,25 @@ const client = axios.create({
   timeout: 30000,
 });
 
-// Attach JWT to every request
+// Attach JWT to every request, and stamp a start time so the request log can
+// report how long each call actually took.
 client.interceptors.request.use((config) => {
   const token = sessionStorage.getItem('token');
   if (token) {
     config.headers.Authorization = `Bearer ${token}`;
   }
+  config.meta = { startedAt: Date.now() };
   return config;
 });
 
 // Redirect to login on 401/403
 client.interceptors.response.use(
-  (response) => response,
+  (response) => {
+    recordResponse(response, response.config?.meta?.startedAt);
+    return response;
+  },
   (error) => {
+    recordError(error, error.config?.meta?.startedAt);
     if (error.response?.status === 401 || error.response?.status === 403) {
       sessionStorage.removeItem('token');
       sessionStorage.removeItem('user');

--- a/src/api/requestLog.js
+++ b/src/api/requestLog.js
@@ -1,0 +1,76 @@
+/**
+ * A ring buffer of recent API calls, for the builder's diagnostics dump.
+ *
+ * Lives at the axios layer so it records every request without each hook
+ * remembering to instrument itself — which is how the interesting ones get
+ * missed. Timings, statuses and rate-limit headers are exactly the evidence
+ * that has been unavailable when a build behaved oddly and the only account of
+ * it was a description after the fact.
+ *
+ * Deliberately records no request bodies and no headers we send: a PATCH on a
+ * pitch carries a real person's contact details, and the Authorization header
+ * carries a token. Method, URL, status, duration and the server's own
+ * rate-limit headers are enough to reconstruct a session.
+ */
+
+const MAX_ENTRIES = 200;
+const entries = [];
+
+/** Response headers worth keeping — all of them from the server, none from us. */
+const KEEP_HEADERS = [
+  'x-ratelimit-limit',
+  'x-ratelimit-remaining',
+  'x-ratelimit-reset',
+  'retry-after',
+];
+
+function pickHeaders(headers) {
+  if (!headers) return undefined;
+  const out = {};
+  for (const key of KEEP_HEADERS) {
+    const value = typeof headers.get === 'function' ? headers.get(key) : headers[key];
+    if (value != null) out[key] = String(value);
+  }
+  return Object.keys(out).length ? out : undefined;
+}
+
+export function record(entry) {
+  entries.push(entry);
+  if (entries.length > MAX_ENTRIES) entries.splice(0, entries.length - MAX_ENTRIES);
+}
+
+export function recordResponse(response, startedAt) {
+  record({
+    at: new Date().toISOString(),
+    method: (response.config?.method || 'get').toUpperCase(),
+    url: response.config?.url,
+    status: response.status,
+    ms: startedAt ? Date.now() - startedAt : null,
+    rate_limit: pickHeaders(response.headers),
+  });
+}
+
+export function recordError(error, startedAt) {
+  const data = error.response?.data;
+  record({
+    at: new Date().toISOString(),
+    method: (error.config?.method || 'get').toUpperCase(),
+    url: error.config?.url,
+    status: error.response?.status ?? null,
+    ms: startedAt ? Date.now() - startedAt : null,
+    rate_limit: pickHeaders(error.response?.headers),
+    // The server's own account of the failure — not the whole body, which can
+    // carry rows of list content.
+    error: typeof data?.error === 'string' ? data.error : error.message,
+    message: typeof data?.message === 'string' ? data.message : undefined,
+  });
+}
+
+/** Newest last. A copy, so a caller can't mutate the buffer. */
+export function recentRequests(limit = MAX_ENTRIES) {
+  return entries.slice(-limit).map(e => ({ ...e }));
+}
+
+export function clearRequestLog() {
+  entries.length = 0;
+}

--- a/src/api/requestLog.test.js
+++ b/src/api/requestLog.test.js
@@ -1,0 +1,61 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearRequestLog, recentRequests, recordError, recordResponse } from './requestLog';
+
+describe('request log', () => {
+  beforeEach(() => clearRequestLog());
+
+  it('records method, url, status and duration', () => {
+    recordResponse(
+      { status: 200, config: { method: 'post', url: '/resolve/batch' }, headers: {} },
+      Date.now() - 9800,
+    );
+    const [entry] = recentRequests();
+    expect(entry.method).toBe('POST');
+    expect(entry.url).toBe('/resolve/batch');
+    expect(entry.ms).toBeGreaterThan(9000);
+  });
+
+  it('keeps the serverrate-limit headers, which are the whole point', () => {
+    recordError(
+      {
+        message: 'Request failed',
+        config: { method: 'get', url: '/search-to-add' },
+        response: { status: 429, headers: { 'retry-after': '37', 'x-ratelimit-remaining': '0' }, data: { error: 'Too many search requests' } },
+      },
+      Date.now() - 40,
+    );
+    const [entry] = recentRequests();
+    expect(entry.status).toBe(429);
+    expect(entry.rate_limit).toEqual({ 'retry-after': '37', 'x-ratelimit-remaining': '0' });
+    expect(entry.error).toBe('Too many search requests');
+  });
+
+  it('never records a request body or anything we sent', () => {
+    // A PATCH on a pitch carries a real person's contact details and the
+    // Authorization header carries a token. Neither belongs in a blob that
+    // gets pasted into a chat window.
+    recordResponse(
+      {
+        status: 200,
+        config: {
+          method: 'patch',
+          url: '/pitches/p_1',
+          data: JSON.stringify({ target_contact: 'ava@example.org' }),
+          headers: { Authorization: 'Bearer secret' },
+        },
+        headers: {},
+      },
+      Date.now(),
+    );
+    expect(JSON.stringify(recentRequests())).not.toMatch(/example\.org|Bearer|secret/);
+  });
+
+  it('is a ring buffer, so a long session cannot grow without bound', () => {
+    for (let i = 0; i < 250; i++) {
+      recordResponse({ status: 200, config: { method: 'get', url: `/x/${i}` }, headers: {} }, Date.now());
+    }
+    const all = recentRequests();
+    expect(all).toHaveLength(200);
+    expect(all[all.length - 1].url).toBe('/x/249');
+  });
+});

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -11,6 +11,7 @@ import {
 } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
 import { typeMatchesPitch } from './pitchRules';
+import { diagnosticsText } from './diagnostics';
 import {
   ROW_STATUS,
   applyBatchResults,
@@ -789,7 +790,23 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         {mismatched.length > 0 && (
           <span className="font-medium text-red-600 tabular-nums">{mismatched.length} wrong type</span>
         )}
-        <div className="ml-auto flex items-center gap-1.5 text-[11px] text-gray-400">
+        <button
+          onClick={async () => {
+            const text = diagnosticsText({ pitchId, thingType, rows, counts });
+            try {
+              await navigator.clipboard.writeText(text);
+              setNote({ ok: true, text: `Diagnostics copied — ${rows.length} row(s) and the recent API calls. No contact details included.` });
+            } catch {
+              // Clipboard can be refused; the console is always available.
+              console.log(text);
+              setNote({ ok: false, text: 'Clipboard refused — the diagnostics are in the browser console instead.' });
+            }
+          }}
+          className="ml-auto text-[11px] text-gray-400 underline decoration-dotted underline-offset-2 hover:text-gray-600"
+        >
+          Copy diagnostics
+        </button>
+        <div className="flex items-center gap-1.5 text-[11px] text-gray-400">
           <span>
             j/k row<Kbd>↑↓</Kbd>
           </span>

--- a/src/pages/concierge/diagnostics.js
+++ b/src/pages/concierge/diagnostics.js
@@ -1,0 +1,46 @@
+import { recentRequests } from '../../api/requestLog';
+import { searchTitle } from './resolveAdapter';
+import { typeMatchesPitch } from './pitchRules';
+
+/**
+ * A structured account of a build, for pasting to whoever is helping debug it.
+ *
+ * Every defect in this builder was found by an operator describing what they
+ * saw and someone else inferring the cause — which took four rounds on one row
+ * and got the cause wrong three times. This is the same information, without
+ * the inference: what each row holds, what the API was asked, and what it said.
+ *
+ * Contains no contact details, no target name and no tokens. Row text is list
+ * content — film titles — and the pitch id identifies a draft, not a person.
+ */
+export function buildDiagnostics({ pitchId, thingType, rows, counts, capturedAt = new Date().toISOString() }) {
+  return {
+    captured_at: capturedAt,
+    pitch_id: pitchId,
+    thing_type: thingType,
+    counts,
+    rows: (rows || []).map((row, i) => ({
+      n: i + 1,
+      raw_text: row.raw_text,
+      // What we actually send the matcher, which is not what the row displays.
+      search_title: searchTitle(row.raw_text),
+      status: row.status,
+      dropped: row.dropped || undefined,
+      thing_id: row.thing_id,
+      matched_title: row.match?.title ?? null,
+      matched_type: row.match?.type ?? null,
+      matched_year: row.match?.year ?? null,
+      wrong_type: row.thing_id && !typeMatchesPitch(row.match?.type, thingType) ? true : undefined,
+      confidence: row.confidence ?? null,
+      reason: row.reason ?? null,
+      candidates: row.candidates?.length || 0,
+      note: row.note || undefined,
+    })),
+    requests: recentRequests(),
+  };
+}
+
+/** The dump as pasteable text. */
+export function diagnosticsText(input) {
+  return JSON.stringify(buildDiagnostics(input), null, 2);
+}

--- a/src/pages/concierge/diagnostics.test.js
+++ b/src/pages/concierge/diagnostics.test.js
@@ -1,0 +1,70 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { buildDiagnostics } from './diagnostics';
+import { clearRequestLog, record } from '../../api/requestLog';
+
+const rows = [
+  {
+    raw_text: 'Persona (1966) 🇸🇪 8.6/10',
+    thing_id: 'tvseries_hignfy_1990',
+    status: 'resolved',
+    match: { title: 'Have I Got News for You', type: 'TVSeries', year: 1990 },
+    candidates: [{ thing_id: 'a' }, { thing_id: 'b' }],
+    confidence: 0.42,
+    reason: null,
+    note: '',
+    dropped: false,
+  },
+  {
+    raw_text: 'The Hunt (2012)',
+    thing_id: 'movie_the_hunt_2012',
+    status: 'resolved',
+    match: { title: 'The Hunt', type: 'Movie', year: 2012 },
+    candidates: [],
+    confidence: 1,
+    reason: null,
+    note: '',
+    dropped: false,
+  },
+];
+
+describe('build diagnostics', () => {
+  beforeEach(() => clearRequestLog());
+
+  it('records what was sent to the matcher, not just what the row shows', () => {
+    // The gap between these two is where three separate defects lived.
+    const d = buildDiagnostics({ pitchId: 'p_1', thingType: 'Movie', rows, counts: { kept: 2 } });
+    expect(d.rows[0].raw_text).toBe('Persona (1966) 🇸🇪 8.6/10');
+    expect(d.rows[0].search_title).toBe('Persona');
+  });
+
+  it('flags a row whose type cannot live on this pitch', () => {
+    const d = buildDiagnostics({ pitchId: 'p_1', thingType: 'Movie', rows, counts: {} });
+    expect(d.rows[0].wrong_type).toBe(true);
+    expect(d.rows[0].matched_type).toBe('TVSeries');
+    expect(d.rows[1].wrong_type).toBeUndefined();
+  });
+
+  it('carries confidence and candidate counts, which prose reports never do', () => {
+    const d = buildDiagnostics({ pitchId: 'p_1', thingType: 'Movie', rows, counts: {} });
+    expect(d.rows[0].confidence).toBe(0.42);
+    expect(d.rows[0].candidates).toBe(2);
+  });
+
+  it('includes the recent API calls with their timings and rate-limit headers', () => {
+    record({ at: '2026-08-25T10:00:00Z', method: 'POST', url: '/resolve/batch', status: 200, ms: 9800 });
+    record({ at: '2026-08-25T10:00:20Z', method: 'GET', url: '/search-to-add', status: 429, ms: 30, rate_limit: { 'retry-after': '41' } });
+    const d = buildDiagnostics({ pitchId: 'p_1', thingType: 'Movie', rows: [], counts: {} });
+    expect(d.requests).toHaveLength(2);
+    expect(d.requests[0].ms).toBe(9800);
+    expect(d.requests[1].status).toBe(429);
+    expect(d.requests[1].rate_limit['retry-after']).toBe('41');
+  });
+
+  it('carries nothing that identifies the target', () => {
+    // The dump gets pasted into a chat window. Row text is list content; a
+    // pitch id names a draft. Contact details, target name and tokens are not
+    // in the builder's state and must never be collected into one blob here.
+    const json = JSON.stringify(buildDiagnostics({ pitchId: 'p_1', thingType: 'Movie', rows, counts: {} }));
+    expect(json).not.toMatch(/target_name|target_contact|@|Bearer|token/i);
+  });
+});


### PR DESCRIPTION
Every defect in this builder was found the same way: an operator described what they saw, and I inferred a cause. That took four rounds on one row and I got the cause wrong three times — matcher, then types, then the save path — because prose can't carry what the row actually held or what the API actually said.

**"Copy diagnostics"** in the summary strip puts it on the clipboard:

- each row's `raw_text` **and** the `search_title` we derive from it — three separate defects lived in exactly that gap
- status, matched title/type/year, `confidence`, candidate count, and whether the type forbids the row
- the recent API calls

## The request log is at the axios layer

Not in each hook — so it captures every call, including the ones nobody thought to instrument. It keeps method, URL, status, **duration** and the server's **rate-limit headers**, which is the evidence for a question we've never been able to answer: does the auto-search actually brush the 20/min ceiling in real use?

## What it deliberately doesn't collect

No request bodies, no headers we send, no contact details. A `PATCH` on a pitch carries a real person's details; the Authorization header carries a token. Neither belongs in a blob pasted into a chat window, and a test asserts the dump matches none of those patterns.

168 tests, including the ring-buffer bound so a long session can't grow without limit.