### PR TITLE
Keep unsaved builder work across a reload

### DIFF
--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -12,6 +12,7 @@ import {
 import { apiErrorMessage } from '../../api/errors';
 import { typeMatchesPitch } from './pitchRules';
 import { diagnosticsText } from './diagnostics';
+import { clearDraft, readDraft, saveDraft } from './draftStore';
 import {
   ROW_STATUS,
   applyBatchResults,
@@ -106,13 +107,19 @@ function CandidateRow({ candidate, chosen, onPick, busy, wrongType }) {
  * bulk-adjudicate fifty rows, so this optimises for throughput.
  */
 export default function PitchBuilder({ pitchId, thingType, items, readOnly, readOnlyReason }) {
-  const [rows, setRows] = useState(() => rowsFromItems(items));
+  // An unsaved build survives a reload. Losing one was previously silent and
+  // total: the pitch looked untouched and every adjudication was gone.
+  const restored = useRef(null);
+  if (restored.current === null) restored.current = { draft: readDraft(pitchId) };
+  const [rows, setRows] = useState(() => restored.current.draft?.rows || rowsFromItems(items));
   const [paste, setPaste] = useState('');
   const [showPaste, setShowPaste] = useState(() => rowsFromItems(items).length === 0);
   const [focus, setFocus] = useState(0);
   const [note, setNote] = useState(null);
   const [busy, setBusy] = useState(null); // 'parsing' | 'resolving' | 'saving' | 'rechecking'
-  const [dirty, setDirty] = useState(false);
+  // Restored work is unsaved by definition, so Save is live and the guards are on.
+  const [dirty, setDirty] = useState(!!restored.current.draft);
+  const [showRestored, setShowRestored] = useState(!!restored.current.draft);
   const [search, setSearch] = useState('');
   const [searchResults, setSearchResults] = useState(null);
   const [urlInput, setUrlInput] = useState('');
@@ -150,9 +157,8 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       // what we sent; the screen already shows it.
       skipNextSeed.current = false;
     } else if (dirty) {
-      // Someone or something changed the stored set while this build was in
-      // progress. Local work wins, but say so rather than silently diverging.
-      setStaleWarning(true);
+      // Restored work is ours and expected; a change arriving mid-build is not.
+      if (!restored.current.draft) setStaleWarning(true);
     } else {
       setRows(rowsFromItems(items));
     }
@@ -160,6 +166,20 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
 
   const cancelled = useRef(false);
   useEffect(() => () => { cancelled.current = true; }, []);
+
+  useEffect(() => {
+    if (readOnly) return;
+    if (dirty && rows.length) saveDraft(pitchId, rows);
+    else if (!dirty) clearDraft(pitchId);
+  }, [rows, dirty, pitchId, readOnly]);
+
+  // The browser's own guard, for the reload that isn't a deliberate discard.
+  useEffect(() => {
+    if (!dirty) return undefined;
+    const onBeforeUnload = e => { e.preventDefault(); e.returnValue = ''; };
+    window.addEventListener('beforeunload', onBeforeUnload);
+    return () => window.removeEventListener('beforeunload', onBeforeUnload);
+  }, [dirty]);
 
   // Latest rows for async work that started before the last render committed.
   const rowsRef = useRef(rows);
@@ -593,6 +613,9 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       // The invalidation this triggers may read a replica that hasn't caught
       // up; don't let that overwrite what we just wrote.
       skipNextSeed.current = true;
+      restored.current.draft = null;
+      setShowRestored(false);
+      clearDraft(pitchId);
       setStaleWarning(false);
       setDirty(false);
       setRows(rs => rs.filter(r => !r.dropped));
@@ -756,6 +779,14 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       {note && (
         <div className={`rounded p-2 text-xs ${note.ok ? 'bg-green-50 text-green-700' : 'bg-amber-50 text-amber-800'}`}>
           {note.text}
+        </div>
+      )}
+
+      {showRestored && dirty && (
+        <div className="rounded border border-indigo-200 bg-indigo-50 p-2 text-xs text-indigo-800">
+          <span className="font-medium">Unsaved work restored.</span> This build was recovered from before the
+          page reloaded — {rows.length} row(s), not yet saved to the pitch. Save to keep it, or reload the
+          pitch from the board to discard it.
         </div>
       )}
 

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -587,3 +587,44 @@ describe('builder — a lagging refetch must not undo the operator', () => {
     expect(screen.getByText(/stored item set changed while you were working/i)).toBeTruthy();
   });
 });
+
+describe('builder — an unsaved build survives a reload', () => {
+  const PASTED = [
+    { raw_text: 'Persona (1966)', thing_id: 'movie_persona_1966_aa', status: 'resolved', candidates: [], match: { title: 'Persona', type: 'Movie', year: 1966 }, note: '', dropped: false, confidence: 1, reason: null },
+  ];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.put.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+    client.put.mockResolvedValue({ data: { success: true, item_count: 1 } });
+  });
+
+  it('restores the rows and says so', () => {
+    // Losing one was silent and total: the pitch looked untouched and every
+    // adjudication since the paste was gone.
+    sessionStorage.setItem('pitchDraft:p_1', JSON.stringify({ v: 1, savedAt: Date.now(), rows: PASTED }));
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={[]} />);
+
+    // Appears in the table and again in the focused-row editor header.
+    expect(screen.getAllByText('Persona (1966)').length).toBeGreaterThan(0);
+    expect(screen.getByText(/Unsaved work restored/i)).toBeTruthy();
+    // Restored work counts as unsaved, so Save is live.
+    expect(screen.getByRole('button', { name: /save items/i }).disabled).toBe(false);
+  });
+
+  it('keeps the draft out of the way once the pitch holds it', async () => {
+    sessionStorage.setItem('pitchDraft:p_1', JSON.stringify({ v: 1, savedAt: Date.now(), rows: PASTED }));
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /save items/i }));
+
+    await vi.waitFor(() => expect(client.put).toHaveBeenCalled());
+    await vi.waitFor(() => expect(sessionStorage.getItem('pitchDraft:p_1')).toBeNull());
+  });
+
+  it('does not restore one pitch draft onto another', () => {
+    sessionStorage.setItem('pitchDraft:p_OTHER', JSON.stringify({ v: 1, savedAt: Date.now(), rows: PASTED }));
+    renderWithProviders(<PitchBuilder pitchId="p_1" thingType="Movie" items={[]} />);
+    expect(screen.queryByText('Persona (1966)')).toBeNull();
+  });
+});

--- a/src/pages/concierge/draftStore.js
+++ b/src/pages/concierge/draftStore.js
@@ -1,0 +1,49 @@
+/**
+ * Local persistence for an in-progress build.
+ *
+ * Rows live in component state until Save, so a reload — or a crash, or a
+ * mis-click on a link — discarded every adjudication made since the paste.
+ * Forty rows of judgement, gone silently, with the pitch looking untouched.
+ *
+ * sessionStorage rather than localStorage: this is scratch work for one tab,
+ * and it should not outlive the tab or leak between staff sharing a machine.
+ * It holds list content — the titles being pitched — and never contact details,
+ * which the builder doesn't have.
+ */
+
+const PREFIX = 'pitchDraft:';
+const VERSION = 1;
+
+function key(pitchId) {
+  return `${PREFIX}${pitchId}`;
+}
+
+export function saveDraft(pitchId, rows) {
+  if (!pitchId) return;
+  try {
+    sessionStorage.setItem(key(pitchId), JSON.stringify({ v: VERSION, savedAt: Date.now(), rows }));
+  } catch {
+    // Quota, or storage disabled. The build still works; it just isn't
+    // recoverable, which is where we were before.
+  }
+}
+
+export function readDraft(pitchId) {
+  if (!pitchId) return null;
+  try {
+    const parsed = JSON.parse(sessionStorage.getItem(key(pitchId)) || 'null');
+    if (!parsed || parsed.v !== VERSION || !Array.isArray(parsed.rows) || parsed.rows.length === 0) return null;
+    return parsed;
+  } catch {
+    return null;
+  }
+}
+
+export function clearDraft(pitchId) {
+  if (!pitchId) return;
+  try {
+    sessionStorage.removeItem(key(pitchId));
+  } catch {
+    /* nothing to do */
+  }
+}

--- a/src/pages/concierge/draftStore.test.js
+++ b/src/pages/concierge/draftStore.test.js
@@ -1,0 +1,44 @@
+import { beforeEach, describe, expect, it } from 'vitest';
+import { clearDraft, readDraft, saveDraft } from './draftStore';
+
+const rows = [{ raw_text: 'Persona (1966)', thing_id: null, status: 'unresolved' }];
+
+describe('draft store', () => {
+  beforeEach(() => sessionStorage.clear());
+
+  it('round-trips an in-progress build', () => {
+    saveDraft('p_1', rows);
+    expect(readDraft('p_1').rows).toEqual(rows);
+  });
+
+  it('keeps drafts separate per pitch', () => {
+    saveDraft('p_1', rows);
+    expect(readDraft('p_2')).toBeNull();
+  });
+
+  it('ignores an empty or malformed draft rather than restoring nothing over real rows', () => {
+    saveDraft('p_1', []);
+    expect(readDraft('p_1')).toBeNull();
+    sessionStorage.setItem('pitchDraft:p_2', '{not json');
+    expect(readDraft('p_2')).toBeNull();
+    sessionStorage.setItem('pitchDraft:p_3', JSON.stringify({ v: 99, rows }));
+    expect(readDraft('p_3')).toBeNull();
+  });
+
+  it('clears once the work is saved', () => {
+    saveDraft('p_1', rows);
+    clearDraft('p_1');
+    expect(readDraft('p_1')).toBeNull();
+  });
+
+  it('survives storage being unavailable', () => {
+    const original = Object.getOwnPropertyDescriptor(window, 'sessionStorage');
+    Object.defineProperty(window, 'sessionStorage', {
+      configurable: true,
+      value: { getItem() { throw new Error('denied'); }, setItem() { throw new Error('denied'); }, removeItem() { throw new Error('denied'); } },
+    });
+    expect(() => saveDraft('p_1', rows)).not.toThrow();
+    expect(readDraft('p_1')).toBeNull();
+    Object.defineProperty(window, 'sessionStorage', original);
+  });
+});

--- a/src/test/setup.js
+++ b/src/test/setup.js
@@ -1,0 +1,12 @@
+import { beforeEach } from 'vitest';
+
+/**
+ * The builder now persists an in-progress build to sessionStorage, so state
+ * leaks between tests unless it's cleared: a draft saved by one case restores
+ * into the next, and the failure looks like a component bug rather than test
+ * contamination.
+ */
+beforeEach(() => {
+  sessionStorage.clear();
+  localStorage.clear();
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -36,6 +36,9 @@ export default defineConfig({
     // jsdom is pinned to ^26: 27 pulls a CJS→ESM require chain that needs
     // Node ≥20.19 (dev is on 20.18).
     environment: 'jsdom',
+    // Clears storage between tests — the builder persists drafts, and a leaked
+    // one restores into the next case.
+    setupFiles: ['./src/test/setup.js'],
     globals: true,
     include: ['src/**/*.test.{js,jsx}'],
     restoreMocks: true,


### PR DESCRIPTION
A 41-row build was lost to a page reload. Rows lived in component state until Save, so the reload discarded every adjudication made since the paste — silently, with the pitch looking untouched.

## What changes

- **Drafts persist.** An in-progress build is written to `sessionStorage` per pitch. One tab, one pitch; it doesn't outlive the tab or leak between staff sharing a machine. It holds list content only — the builder never sees contact details.
- **Restored work is announced.** Coming back to a builder with a recovered draft shows the rows plus a banner saying they are recovered and unsaved, rather than an empty paste box. Save is live; the draft clears once the pitch holds the work.
- **`beforeunload` guard** for the reload that wasn't a deliberate discard.
- The stale-set warning is suppressed for a restore. What that warning flags is someone else changing the stored set mid-build, not our own recovered work.

## Notes

- Every storage call is failure-tolerant. Quota exhausted or storage disabled lands exactly where we were before, not on an error.
- Tests now clear browser storage between cases — without it a draft saved by one test restores into the next and the failure reads as a component bug.

`npm test` (176), lint, typecheck and build pass.