### PR TITLE
Ask the matcher for the title, not the whole table row

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -130,6 +130,22 @@ registry first. There is no free-text escape hatch: with a live vocabulary, free
 `/imports/parse` failures fall back to splitting pasted text one item per line, so a build can still
 proceed by hand.
 
+### What the matcher is actually asked
+
+The row shows the pasted text; the matcher gets `queryFor(row).title`, which is not the same string.
+Pasted blocks go through `tableQueries()` in `resolveAdapter.ts`, which reads the block as a whole
+because the ambiguous parts of a table row cannot be read from one row: a leading integer is a rank in
+`1 It 2017 $719,766,009 [1][2]` and the title in `28 Days Later`, and a trailing year is a column here
+and part of the name in `Blade Runner 2049`. A rank column is only believed when most rows start with an
+ascending integer *and* either the numbers step by one or the rest of the block carries money and
+reference columns. Column headings — a first row with no rank where every item row has one — arrive
+dropped, struck through, and one `x` puts them back.
+
+Reference marks, currency amounts and footnote daggers are stripped per row regardless, since none of
+them is ever part of a title. When a resolve goes wrong, **Copy diagnostics** reports `search_title` and
+`search_year` beside `raw_text`; if those two are identical the cleaner did nothing, which is the first
+thing to check.
+
 ## Verifying against prod
 
 Prod is the only environment, and this feature writes **real people's contact details**. Anything created

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -22,7 +22,7 @@ import {
   normalizeParseOutcome,
   normalizeParsed,
   normalizeSearchResults,
-  searchTitle,
+  queryFor,
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
@@ -193,7 +193,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     .map((row, i) => ({ row, i }))
     .filter(({ row }) => !row.dropped && row.thing_id && !typeMatchesPitch(row.match?.type, thingType));
   const focusedRow = rows[focus];
-  const prefill = focusedRow ? searchTitle(focusedRow.raw_text) : '';
+  const prefill = focusedRow ? queryFor(focusedRow).title : '';
 
   // Moving to another row re-arms the box for that row: the previous row's
   // query and results are meaningless here. Keyed on the row's identity rather
@@ -569,7 +569,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         // that the link WAS understood.
         setBusy(null);
         setCreatable({ url: url.trim(), idText, row: focus });
-        await runSearch(searchTitle(focusedRow?.raw_text || ''), {
+        await runSearch(focusedRow ? queryFor(focusedRow).title : '', {
           context: `Link read${idText ? ` (${idText})` : ''} but not in our registry — `,
         });
         return;
@@ -1005,13 +1005,13 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                 className="flex gap-2"
                 onSubmit={e => {
                   e.preventDefault();
-                  runSearch(search || searchTitle(focusedRow.raw_text));
+                  runSearch(search || queryFor(focusedRow).title);
                 }}
               >
                 <TextInput
                   value={search}
                   onChange={e => setSearch(e.target.value)}
-                  placeholder={`Search catalogue — “${searchTitle(focusedRow.raw_text).slice(0, 32)}”`}
+                  placeholder={`Search catalogue — “${queryFor(focusedRow).title.slice(0, 32)}”`}
                 />
                 <Button type="submit" disabled={busy === 'searching'}>
                   Search

--- a/src/pages/concierge/diagnostics.js
+++ b/src/pages/concierge/diagnostics.js
@@ -1,5 +1,5 @@
 import { recentRequests } from '../../api/requestLog';
-import { searchTitle } from './resolveAdapter';
+import { queryFor } from './resolveAdapter';
 import { typeMatchesPitch } from './pitchRules';
 
 /**
@@ -23,7 +23,8 @@ export function buildDiagnostics({ pitchId, thingType, rows, counts, capturedAt 
       n: i + 1,
       raw_text: row.raw_text,
       // What we actually send the matcher, which is not what the row displays.
-      search_title: searchTitle(row.raw_text),
+      search_title: queryFor(row).title,
+      search_year: queryFor(row).year,
       status: row.status,
       dropped: row.dropped || undefined,
       thing_id: row.thing_id,

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -13,6 +13,8 @@ import {
   rowsFromParsed,
   extractYear,
   searchTitle,
+  tableQueries,
+  queryFor,
   summarize,
   toBatchPayload,
   toItemsPayload,
@@ -423,5 +425,92 @@ describe('normalizeParseOutcome — a clipped paste must not look complete', () 
     // A parser that says nothing has not said it clipped; don't invent a warning.
     expect(normalizeParseOutcome({ candidates: [] }).truncated).toBe(false);
     expect(normalizeParseOutcome(null).truncated).toBe(false);
+  });
+});
+
+describe('tableQueries — a pasted table, read as a block', () => {
+  // Verbatim from the run that sent all 41 of these to the matcher as titles.
+  const HORROR = [
+    'Rank Film Year Worldwide gross Ref',
+    '1 It 2017 $719,766,009 [1][2]',
+    '2 The Sixth Sense 1999 $672,806,292 [3][4]',
+    '3 I Am Legend 2007 $585,532,684 [5][6]',
+    '4 World War Z 2013 $540,007,876 [7][8]',
+    '5 Obsession \u2020 2026 $501,596,715 [9][10]',
+    '6 The Conjuring: Last Rites 2025 $499,256,445 [11][12]',
+    '11 Signs 2002 $408,250,578 [21][22]',
+    '39 The Ring 2002 $249,348,933 [77][78]',
+  ];
+
+  it('asks for the title, not the whole row', () => {
+    const q = tableQueries(HORROR);
+    expect(q.map(r => r.title)).toEqual([
+      'Rank Film Year Worldwide gross Ref',
+      'It',
+      'The Sixth Sense',
+      'I Am Legend',
+      'World War Z',
+      'Obsession',
+      'The Conjuring: Last Rites',
+      'Signs',
+      'The Ring',
+    ]);
+  });
+
+  it('reads the year column as the year', () => {
+    expect(tableQueries(HORROR).map(r => r.year)).toEqual([
+      null, 2017, 1999, 2007, 2013, 2026, 2025, 2002, 2002,
+    ]);
+  });
+
+  it('marks the heading row, and nothing else', () => {
+    const q = tableQueries(HORROR);
+    expect(q[0].header).toBe(true);
+    expect(q.slice(1).every(r => r.header === false)).toBe(true);
+  });
+
+  it('keeps a number that is part of the title', () => {
+    // No rank column here: the leading integers do not count up.
+    const titles = tableQueries(['28 Days Later', '12 Angry Men', '300', '1917']).map(r => r.title);
+    expect(titles).toEqual(['28 Days Later', '12 Angry Men', '300', '1917']);
+  });
+
+  it('keeps a year that is part of the title', () => {
+    // Two years on the row: the column is the trailing one.
+    const [q] = tableQueries([
+      '17 Blade Runner 2049 2017 $259,239,658 [1]',
+      '18 Alien 1979 $203,630,630 [2]',
+      '19 Arrival 2016 $203,388,186 [3]',
+    ]);
+    expect(q.title).toBe('Blade Runner 2049');
+    expect(q.year).toBe(2017);
+  });
+
+  it('leaves a plain list alone', () => {
+    // "Blade Runner 2049" outside a table is a name, not a name and a year.
+    expect(tableQueries(['Blade Runner 2049', 'Arrival', 'Dune']).map(r => r.title)).toEqual([
+      'Blade Runner 2049', 'Arrival', 'Dune',
+    ]);
+  });
+
+  it('handles an empty block', () => {
+    expect(tableQueries([])).toEqual([]);
+    expect(tableQueries(['', '  '])).toEqual([
+      { title: '', year: null, header: false },
+      { title: '', year: null, header: false },
+    ]);
+  });
+});
+
+describe('queryFor', () => {
+  const row = raw => ({ raw_text: raw, thing_id: null, status: 'unresolved', candidates: [], match: null, note: '', dropped: false, confidence: null, reason: null });
+
+  it('uses what the block-aware pass worked out', () => {
+    expect(queryFor({ ...row('1 It 2017 $719,766,009 [1][2]'), query: { title: 'It', year: 2017, header: false } }))
+      .toEqual({ title: 'It', year: 2017, header: false });
+  });
+
+  it('falls back to the row alone for a link or a catalogue pick', () => {
+    expect(queryFor(row('Persona (1966)'))).toEqual({ title: 'Persona', year: 1966, header: false });
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -61,6 +61,8 @@ export interface BuilderRow {
   dropped: boolean;
   confidence: number | null;
   reason: string | null;
+  /** Set for pasted rows: what the block-aware cleaner made of the raw text. */
+  query?: RowQuery | null;
 }
 
 /** The part of a row that resolution owns. */
@@ -325,6 +327,100 @@ export function chunkForBatch(indices: number[], size: number = BATCH_LIMIT): nu
  * `raw_text` is left untouched: it's what the operator recognises, and what the
  * target inherits on an unresolved row.
  */
+/** Structural noise that is never part of a title, whatever the paste looks like. */
+const REF_MARKS = /\s*\[\s*\d+\s*\]/g;
+const FOOTNOTE_MARKS = /[\u2020\u2021]/g;
+const MONEY = /\s*[$\u00a3\u20ac\u00a5]\s?\d[\d,]*(?:\.\d+)?(?:\s*(?:million|billion|bn|m)\b)?/gi;
+/** A leading integer with no punctuation after it — a rank cell, or a title. */
+const RANK_CELL = /^\s*(\d{1,3})\s+(?=\S)/;
+const TRAILING_YEAR = /\s+((?:19|20)\d{2})\s*$/;
+
+/** What we actually ask the matcher for, per row. */
+export interface RowQuery {
+  title: string;
+  year: number | null;
+  /** A column-heading row rather than an item — "Rank Film Year Gross Ref". */
+  header: boolean;
+}
+
+/**
+ * Clean a whole pasted block at once, because the ambiguous parts of a table
+ * row can only be read from the block.
+ *
+ * A pasted Wikipedia table row looks like `1 It 2017 $719,766,009 [1][2]`, and
+ * per-row rules cannot safely strip either end of it: a leading integer is a
+ * rank in that table and the title in `28 Days Later`, and a trailing year is
+ * a year column here and part of the name in `Blade Runner 2049`. Across the
+ * block the ambiguity resolves — a rank column counts 1, 2, 3 down the rows,
+ * and a year column only appears alongside the other columns.
+ *
+ * This was not academic: a 41-row paste of the highest-grossing horror films
+ * sent every one of those strings to the matcher as the title. The long
+ * distinctive names survived it; `It`, `Signs` and `The Ring` drowned in the
+ * noise and came back with no candidates at all.
+ */
+export function tableQueries(rawTexts: string[]): RowQuery[] {
+  const texts = (rawTexts || []).map(t => t || '');
+
+  // A rank column: most rows open with a bare integer and those integers climb.
+  // Ascending alone is too weak — 12 Angry Men, 28 Days Later, 300 climb by
+  // accident — so it also takes one of two corroborations: the numbers step by
+  // one, or the rest of the block is visibly tabular. The second matters,
+  // because an operator who deletes a few rows leaves gaps in the numbering
+  // and the sequence test alone would then hand the ranks to the matcher.
+  const ranks = texts.map(t => {
+    const m = t.match(RANK_CELL);
+    return m ? Number(m[1]) : null;
+  });
+  const present = ranks.filter((r): r is number => r !== null);
+  const ascending = present.every((r, i) => i === 0 || r > present[i - 1]);
+  const steps = present.filter((r, i) => i > 0 && r === present[i - 1] + 1).length;
+  const columnar = texts.filter(t => t.replace(REF_MARKS, '').replace(MONEY, ' ') !== t).length;
+  const rankColumn =
+    present.length >= 3 &&
+    present.length >= texts.length * 0.6 &&
+    ascending &&
+    (steps >= (present.length - 1) * 0.8 || columnar >= texts.length * 0.6);
+
+  return texts.map((raw, i) => {
+    // A heading only reads as one against the table it heads: every item row
+    // carries a rank and this one doesn't.
+    const header = rankColumn && i === 0 && ranks[0] === null;
+
+    let text = raw.replace(REF_MARKS, '').replace(FOOTNOTE_MARKS, ' ').replace(MONEY, ' ');
+    // Only these columns prove the row is tabular. Without them a trailing
+    // year is just as likely to be part of the name.
+    let tabular = text !== raw;
+    if (rankColumn && ranks[i] !== null) {
+      text = text.replace(RANK_CELL, '');
+      tabular = true;
+    }
+
+    let year: number | null = null;
+    if (tabular) {
+      const m = text.match(TRAILING_YEAR);
+      // "Blade Runner 2049 2017" gives up the year column and keeps its name;
+      // a row that is only a year ("1917") keeps all of it.
+      if (m && text.replace(TRAILING_YEAR, '').trim()) {
+        year = Number(m[1]);
+        text = text.replace(TRAILING_YEAR, '');
+      }
+    }
+
+    return { title: searchTitle(text), year: year ?? extractYear(raw), header };
+  });
+}
+
+/**
+ * The query for one row. Rows built from a paste carry the block-aware result;
+ * anything else — a link, a catalogue pick, a saved item — falls back to what
+ * can be read from the row alone.
+ */
+export function queryFor(row: BuilderRow): RowQuery {
+  if (row.query) return row.query;
+  return { title: searchTitle(row.raw_text), year: extractYear(row.raw_text), header: false };
+}
+
 export function searchTitle(rawText: string): string {
   return (rawText || '')
     // leading list decoration the parser may leave behind
@@ -336,6 +432,11 @@ export function searchTitle(rawText: string): string {
     .replace(/[\u{1F1E6}-\u{1F1FF}\u{1F300}-\u{1FAFF}\u{2600}-\u{27BF}\u{FE0F}]/gu, '')
     // a trailing year, or a run of them: "(1971, 1972)"
     .replace(/\s*\((?:\s*(?:19|20)\d{2}\s*,?)+\)\s*/g, ' ')
+    // wikipedia reference marks and the footnote daggers beside them
+    .replace(REF_MARKS, '')
+    .replace(FOOTNOTE_MARKS, ' ')
+    // box-office columns: "$719,766,009", "£12.4 million"
+    .replace(MONEY, ' ')
     // whatever separators the decoration left stranded
     .replace(/\s*[|·–—-]\s*$/, '')
     .replace(/\s{2,}/g, ' ')
@@ -365,11 +466,10 @@ export function toBatchPayload(
   fallbackType: string,
 ): ResolveRequest[] {
   return indices.map(rowIndex => {
-    const raw = rows[rowIndex].raw_text;
-    const year = extractYear(raw);
+    const { title, year } = queryFor(rows[rowIndex]);
     return {
       type: fallbackType,
-      title: searchTitle(raw),
+      title,
       ...(year ? { year } : {}),
     };
   });
@@ -446,16 +546,20 @@ export function summarize(rows: Pick<BuilderRow, 'status' | 'dropped'>[]): RowCo
 
 /** Rows straight from pasted text, before any resolution has run. */
 export function rowsFromParsed(parsed: ParsedCandidate[]): BuilderRow[] {
-  return parsed.map(p => ({
+  const queries = tableQueries(parsed.map(p => p.raw_text));
+  return parsed.map((p, i) => ({
     raw_text: p.raw_text,
     thing_id: null,
     status: 'unresolved',
     candidates: [],
     match: null,
-    note: '',
-    dropped: false,
+    // Dropped rather than removed: it stays visible and struck through, and
+    // one keystroke puts it back if the guess was wrong.
+    note: queries[i].header ? 'Column headings, not an item.' : '',
+    dropped: queries[i].header,
     confidence: null,
     reason: null,
+    query: queries[i],
   }));
 }
 


### PR DESCRIPTION
A 41-row paste of the Wikipedia highest-grossing-horror table resolved 31 and lost 10. The diagnostics dump showed why: `search_title` was byte-identical to `raw_text` on **all 41 rows**, so the matcher was asked for `"1 It 2017 $719,766,009 [1][2]"`. Distinctive names survived the noise; `It`, `Signs` and `The Ring` came back with no candidates at all.

## Why per-row rules can't fix it

Neither end of a table row is readable on its own:

- a leading integer is a rank in `1 It 2017 …` and the title in `28 Days Later`
- a trailing year is a column in `17 Blade Runner 2049 2017 …` and part of the name in `Blade Runner 2049`

Across the block it resolves — so `tableQueries()` cleans a pasted block as a whole, and rows carry the query it produced. `queryFor(row)` is now the single place anything asks what to search for: batch resolve, the search prefill, the placeholder, diagnostics.

## Rules

- **Rank column** — most rows open with an ascending integer, *plus* corroboration: either the numbers step by one, or the block is visibly tabular. Gaps happen (an operator deletes a few rows), so the sequence test alone would still have handed ranks to the matcher.
- **Year column** — a trailing year is only taken when the row proved tabular some other way. `Blade Runner 2049 2017` gives up the column and keeps its name; a plain `Blade Runner 2049` is untouched.
- **Column headings** — a first row with no rank where every item row has one arrives *dropped*, not removed: struck through, with a note, one `x` to undo.
- **Always safe, every paste** — reference marks `[1][2]`, currency amounts, footnote daggers.

## Verification

Tests use the operator's actual 41-row paste as the fixture, and cover the false positives the rules exist to avoid (`28 Days Later`, `12 Angry Men`, `300`, `1917`, a plain `Blade Runner 2049`).

I have not re-run the paste against prod — that needs an admin session. Removing the noise is what this fixes; whether a bare `It` then resolves is the matcher's call, and the re-run will say.

`npm test` (185), lint, typecheck, build pass. Playbook section added: `docs/concierge-admin.md`.