### PR TITLE
Catch the same item twice, and say when a match is there to pick

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -142,7 +142,22 @@ reference columns. Column headings — a first row with no rank where every item
 dropped, struck through, and one `x` puts them back.
 
 Reference marks, currency amounts and footnote daggers are stripped per row regardless, since none of
-them is ever part of a title. When a resolve goes wrong, **Copy diagnostics** reports `search_title` and
+them is ever part of a title.
+
+### Duplicates
+
+Two checks, because they catch different things. Pasting again skips lines already on the list and says
+how many — a build survives a reload now, so a re-paste lands on rows that are still there. Separately,
+two rows that *resolved* to the same thing are reported by row number with a one-click drop, and block
+the save the way a type mismatch does. Only the resolved ids expose those; the text check cannot see
+them.
+
+### Ambiguous vs unresolved
+
+A server `no_match` that ships suggestions is reported **ambiguous** — "not confident, you pick" — and
+only a `no_match` with nothing to offer is unresolved. A suggestion is never adopted as the resolution
+whichever way it is labelled. Before this split, three films in a 40-row build read as failures with the
+correct match already sitting in their candidate lists. When a resolve goes wrong, **Copy diagnostics** reports `search_title` and
 `search_year` beside `raw_text`; if those two are identical the cleaner did nothing, which is the first
 thing to check.
 

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -23,6 +23,8 @@ import {
   normalizeParsed,
   normalizeSearchResults,
   queryFor,
+  dedupeAgainst,
+  duplicateIndices,
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
@@ -192,6 +194,9 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   const mismatched = rows
     .map((row, i) => ({ row, i }))
     .filter(({ row }) => !row.dropped && row.thing_id && !typeMatchesPitch(row.match?.type, thingType));
+  // Two rows pointing at one film. Distinct from the paste-time text check:
+  // these arrive from resolution, so only the matched ids expose them.
+  const duplicates = duplicateIndices(rows);
   const focusedRow = rows[focus];
   const prefill = focusedRow ? queryFor(focusedRow).title : '';
 
@@ -311,7 +316,12 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         text: `Parser unreachable (${apiErrorMessage(err)}). Split ${parsed.length} line(s) locally instead.`,
       });
     }
-    const fresh = rowsFromParsed(parsed);
+    const parsedRows = rowsFromParsed(parsed);
+    // Appending the same list twice is the easy mistake — the builder keeps
+    // unsaved work now, so a re-paste lands on rows that are already there.
+    const { rows: fresh, skipped } = replace
+      ? { rows: parsedRows, skipped: 0 }
+      : dedupeAgainst(rows, parsedRows);
     const next = replace ? fresh : [...rows, ...fresh];
     setRows(next);
     setDirty(true);
@@ -320,8 +330,14 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     setBusy(null);
     const startAt = replace ? 0 : rows.length;
     await resolveIndices(fresh.map((_, i) => startAt + i), { source: next });
-    // After the resolve, so it isn't overwritten by the resolve's own note.
+    // After the resolve, so neither is overwritten by the resolve's own note.
     if (clipped) setNote({ ok: false, text: clipped });
+    else if (skipped > 0) {
+      setNote({
+        ok: true,
+        text: `Added ${fresh.length} row(s). Skipped ${skipped} already on the list — re-paste with Replace if you meant to start over.`,
+      });
+    }
   }
 
   /**
@@ -605,6 +621,15 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       });
       return;
     }
+    if (duplicates.length > 0) {
+      setNote({
+        ok: false,
+        text: `Not saved — row ${duplicates.map(i => i + 1).join(', ')} ${
+          duplicates.length === 1 ? 'repeats an item' : 'repeat items'
+        } already on the list. Drop the repeats, or keep them deliberately by re-matching.`,
+      });
+      return;
+    }
     setBusy('saving');
     setNote(null);
     try {
@@ -808,6 +833,27 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         </div>
       )}
 
+      {duplicates.length > 0 && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+          <span className="font-medium">
+            Row {duplicates.map(i => i + 1).join(', ')} {duplicates.length === 1 ? 'is' : 'are'} already on
+            this list.
+          </span>{' '}
+          The same film twice reads as carelessness on the pitch itself. Dropping keeps the first of each.
+          <button
+            onClick={() => {
+              const drop = new Set(duplicates);
+              setRows(rs => rs.map((r, i) => (drop.has(i) ? { ...r, dropped: true } : r)));
+              setDirty(true);
+            }}
+            disabled={readOnly}
+            className="ml-2 font-medium underline decoration-dotted underline-offset-2 disabled:no-underline disabled:opacity-50"
+          >
+            Drop {duplicates.length === 1 ? 'it' : `all ${duplicates.length}`}
+          </button>
+        </div>
+      )}
+
       {/* Summary */}
       <div className="flex flex-wrap items-center gap-3 text-xs text-gray-500">
         <span className="tabular-nums">
@@ -820,6 +866,9 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         {counts.dropped > 0 && <span className="tabular-nums text-gray-400">{counts.dropped} dropped</span>}
         {mismatched.length > 0 && (
           <span className="font-medium text-red-600 tabular-nums">{mismatched.length} wrong type</span>
+        )}
+        {duplicates.length > 0 && (
+          <span className="font-medium text-amber-600 tabular-nums">{duplicates.length} duplicate</span>
         )}
         <button
           onClick={async () => {
@@ -891,7 +940,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
             <Button
               variant="primary"
               onClick={save}
-              disabled={!!busy || rows.length === 0 || mismatched.length > 0}
+              disabled={!!busy || rows.length === 0 || mismatched.length > 0 || duplicates.length > 0}
               title={
                 mismatched.length > 0
                   ? `Row ${mismatched.map(m => m.i + 1).join(', ')} ${mismatched.length === 1 ? 'is' : 'are'} the wrong type for a ${thingType} pitch`

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -628,3 +628,40 @@ describe('builder — an unsaved build survives a reload', () => {
     expect(screen.queryByText('Persona (1966)')).toBeNull();
   });
 });
+
+describe('builder — the same item twice', () => {
+  const twice = [
+    { raw_text: 'Alien', thing_id: 'movie_alien_1979', status: 'resolved', candidates: [], match: { title: 'Alien', type: 'Movie', year: 1979 }, note: '', dropped: false, confidence: 1, reason: null },
+    { raw_text: 'Alien (1979)', thing_id: 'movie_alien_1979', status: 'resolved', candidates: [], match: { title: 'Alien', type: 'Movie', year: 1979 }, note: '', dropped: false, confidence: 1, reason: null },
+  ];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.put.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+    client.put.mockResolvedValue({ data: { success: true, item_count: 2 } });
+    sessionStorage.setItem('pitchDraft:p_dup', JSON.stringify({ v: 1, savedAt: Date.now(), rows: twice }));
+  });
+
+  it('names the repeat and refuses to save it', async () => {
+    renderWithProviders(<PitchBuilder pitchId="p_dup" thingType="Movie" items={[]} />);
+    expect(screen.getByText(/Row 2 is already on this list/i)).toBeTruthy();
+
+    // The `s` shortcut bypasses the disabled button, so guard the operation.
+    fireEvent.keyDown(window, { key: 's' });
+    await vi.waitFor(() => expect(screen.getByText(/Not saved — row 2 repeats an item/i)).toBeTruthy());
+    expect(client.put).not.toHaveBeenCalled();
+  });
+
+  it('drops the repeat and keeps the first, then saves', async () => {
+    renderWithProviders(<PitchBuilder pitchId="p_dup" thingType="Movie" items={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /^Drop it$/i }));
+
+    expect(screen.queryByText(/already on this list/i)).toBeNull();
+    fireEvent.click(screen.getByRole('button', { name: /save items/i }));
+    await vi.waitFor(() => expect(client.put).toHaveBeenCalled());
+    const sent = client.put.mock.calls[0][1].items;
+    expect(sent).toHaveLength(1);
+    expect(sent[0].thing_id).toBe('movie_alien_1979');
+  });
+});

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -15,6 +15,8 @@ import {
   searchTitle,
   tableQueries,
   queryFor,
+  dedupeAgainst,
+  duplicateIndices,
   summarize,
   toBatchPayload,
   toItemsPayload,
@@ -63,16 +65,29 @@ describe('the shapes prod actually returns', () => {
     // The server said it could not match this. One suggestion is an option for
     // the operator, not a resolution — adopting it would silently invent a link.
     const res = normalizeResolution(PROD_NO_MATCH);
-    expect(res.status).toBe('unresolved');
     expect(res.thing_id).toBeNull();
     expect(res.candidates).toHaveLength(1);
     expect(res.reason).toBe('no_confident_match');
   });
 
+  it('calls a no_match that carries suggestions ambiguous, not unresolved', () => {
+    // "Not confident, you pick" is a different instruction from "no such
+    // thing", and reporting both as unresolved gave the operator no reason to
+    // open the row. Three films in a 40-row build sat as failures with the
+    // right match already sitting in their candidate list.
+    expect(normalizeResolution(PROD_NO_MATCH).status).toBe('ambiguous');
+  });
+
+  it('still calls a no_match with nothing to offer unresolved', () => {
+    const res = normalizeResolution({ ...PROD_NO_MATCH, suggestions: [] });
+    expect(res.status).toBe('unresolved');
+    expect(res.thing_id).toBeNull();
+  });
+
   it('maps the batch envelope back onto rows', () => {
     const rows = rowsFromParsed(normalizeParsed(['The Matrix', 'zzzz nonsense qqq']));
     const next = applyBatchResults(rows, batchResults({ results: [PROD_FOUND, PROD_NO_MATCH], count: 2 }), [0, 1]);
-    expect(next.map(r => r.status)).toEqual(['resolved', 'unresolved']);
+    expect(next.map(r => r.status)).toEqual(['resolved', 'ambiguous']);
   });
 
   it('parses the real /imports/parse envelope, 0-based positions and all', () => {
@@ -172,9 +187,14 @@ describe('normalizeParsed', () => {
 });
 
 describe('batching', () => {
-  it('splits at the 200-item rate-limit unit', () => {
-    const chunks = chunkForBatch([...Array(450).keys()]);
+  it('splits at the rate-limit unit', () => {
+    const chunks = chunkForBatch([...Array(250).keys()]);
     expect(chunks.map(c => c.length)).toEqual([BATCH_LIMIT, BATCH_LIMIT, 50]);
+  });
+
+  it('keeps a full chunk clear of the server deadline', () => {
+    // ~0.25s an item measured against prod, against a 60s server deadline.
+    expect(BATCH_LIMIT * 0.25).toBeLessThan(40);
   });
 
   it('sends a batch payload in the order the indices were given', () => {
@@ -512,5 +532,45 @@ describe('queryFor', () => {
 
   it('falls back to the row alone for a link or a catalogue pick', () => {
     expect(queryFor(row('Persona (1966)'))).toEqual({ title: 'Persona', year: 1966, header: false });
+  });
+});
+
+describe('duplicates', () => {
+  const row = (raw, thingId = null) => ({
+    raw_text: raw, thing_id: thingId, status: thingId ? 'resolved' : 'unresolved',
+    candidates: [], match: null, note: '', dropped: false, confidence: null, reason: null,
+  });
+
+  it('skips a re-paste of lines already on the list', () => {
+    // The builder keeps unsaved work now, so pasting again lands on rows that
+    // are already there: a 40-film list became 82 rows.
+    const existing = [row('1 It 2017 $719,766,009 [1][2]'), row('2 The Sixth Sense 1999 $672,806,292 [3][4]')];
+    const { rows, skipped } = dedupeAgainst(existing, [
+      row('1 It 2017 $719,766,009 [1][2]'),
+      row('  2 THE SIXTH SENSE 1999 $672,806,292 [3][4] '),
+      row('3 I Am Legend 2007 $585,532,684 [5][6]'),
+    ]);
+    expect(skipped).toBe(2);
+    expect(rows.map(r => r.raw_text)).toEqual(['3 I Am Legend 2007 $585,532,684 [5][6]']);
+  });
+
+  it('does not treat a dropped row as occupying the list', () => {
+    const existing = [{ ...row('Jaws'), dropped: true }];
+    expect(dedupeAgainst(existing, [row('Jaws')]).skipped).toBe(0);
+  });
+
+  it('catches two different lines that resolved to one film', () => {
+    const rows = [row('Alien', 'movie_alien_1979'), row('Alien (1979)', 'movie_alien_1979'), row('Jaws', 'movie_jaws_1975')];
+    // The first of each is kept; only the repeat is reported.
+    expect(duplicateIndices(rows)).toEqual([1]);
+  });
+
+  it('does not call two unresolved rows duplicates of each other', () => {
+    expect(duplicateIndices([row('Obsession'), row('Obsession')])).toEqual([]);
+  });
+
+  it('ignores a dropped repeat', () => {
+    const rows = [row('Alien', 'movie_alien_1979'), { ...row('Alien', 'movie_alien_1979'), dropped: true }];
+    expect(duplicateIndices(rows)).toEqual([]);
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -20,7 +20,15 @@
 // `suggestions` is the alternates list — on a `no_match` it is what the operator
 // picks from, so it must never be auto-adopted as the resolution.
 
-export const BATCH_LIMIT = 200; // one rate-limit unit per call
+/**
+ * Rows per /resolve/batch call — one rate-limit unit each.
+ *
+ * 100, not the 200 the endpoint allows: measured against prod, a batch costs
+ * ~0.25s an item (41 items 10.7s, 82 items 20.2s), so a full 200 would run ~49s
+ * into the server's 60s deadline and time out the whole chunk on any bad day.
+ * Halving it costs one extra unit per 100 items and takes that off the table.
+ */
+export const BATCH_LIMIT = 100;
 
 export type RowStatus = 'resolved' | 'ambiguous' | 'unresolved' | 'pending';
 
@@ -250,7 +258,14 @@ export function normalizeResolution(raw: unknown): Resolution {
   const thingId = explicitId || (!mapped && candidates.length === 1 ? candidates[0].thing_id : null);
 
   let status: RowStatus;
-  if (mapped) status = mapped;
+  // A `no_match` carrying suggestions is not a dead end — it is the server
+  // saying "not confident, you pick". Reported as unresolved it read as "this
+  // does not exist", and the operator had no reason to open the row: in a
+  // 40-row build, Hannibal and two Resident Evils sat there as failures with
+  // the right film already in hand. The thing_id stays null either way; this
+  // changes what we call it, never what we adopt.
+  if (mapped === 'unresolved' && !thingId && candidates.length > 0) status = 'ambiguous';
+  else if (mapped) status = mapped;
   else if (thingId) status = 'resolved';
   else status = candidates.length > 1 ? 'ambiguous' : 'unresolved';
   // A row with no thing_id is never "resolved", whatever the server called it.
@@ -528,6 +543,52 @@ export function toItemsPayload(rows: BuilderRow[]): ItemPayload[] {
       resolution_status: row.thing_id ? 'resolved' : 'ambiguous',
       note: row.note?.trim() ? row.note.trim() : null,
     }));
+}
+
+/** Same pasted line twice — the key that survives a re-paste of the same list. */
+function textKey(row: Pick<BuilderRow, 'raw_text'>): string {
+  return (row.raw_text || '').trim().toLowerCase().replace(/\s+/g, ' ');
+}
+
+/**
+ * Incoming rows minus the ones already on the board.
+ *
+ * Appending a second paste of the same list produced 82 rows for a 40-film
+ * list, half of them stale copies resolved from the older, noisier titles.
+ * Nothing downstream would have caught it: a list can legitimately be built by
+ * appending, so quantity is no signal.
+ */
+export function dedupeAgainst(
+  existing: BuilderRow[],
+  incoming: BuilderRow[],
+): { rows: BuilderRow[]; skipped: number } {
+  const seen = new Set(existing.filter(r => !r.dropped).map(textKey));
+  const rows: BuilderRow[] = [];
+  for (const row of incoming) {
+    const k = textKey(row);
+    // Blank lines can't collide with each other in any meaningful way.
+    if (k && seen.has(k)) continue;
+    if (k) seen.add(k);
+    rows.push(row);
+  }
+  return { rows, skipped: incoming.length - rows.length };
+}
+
+/**
+ * Kept rows that resolved to the same thing, beyond the first of each.
+ *
+ * The text-level check can't see these: two different lines ("Alien" and
+ * "Alien (1979)") resolving to one film is the same item twice on the list.
+ */
+export function duplicateIndices(rows: BuilderRow[]): number[] {
+  const first = new Map<string, number>();
+  const dupes: number[] = [];
+  rows.forEach((row, i) => {
+    if (row.dropped || !row.thing_id) return;
+    if (first.has(row.thing_id)) dupes.push(i);
+    else first.set(row.thing_id, i);
+  });
+  return dupes;
 }
 
 /** Counts for the builder's summary strip. */


### PR DESCRIPTION
Two defects from a 40-row build, both in the same diagnostics dump. The table-paste fix worked — 37 of 40 rows resolved, including `It`, `Signs` and `The Ring`, which had returned nothing before — so what was left underneath became visible.

## Duplicates: 82 rows for a 40-film list

Re-pasting produced two copies of every row. That's a consequence of keeping unsaved work: the build survives a reload now, so a second paste lands on rows that are still there. Nothing downstream would have caught it — appending is a legitimate way to build a list, so quantity is no signal.

Two checks, because they catch different things:

- **On paste** — lines already on the list are skipped, with a count and a pointer to Replace. Dropped rows don't count as occupying the list.
- **Standing** — any two kept rows resolving to the same thing are named by row number, with a one-click drop that keeps the first of each. This blocks the save, guarding the operation rather than the button, since `s` reaches save without it. Only matched ids expose these; `Alien` and `Alien (1979)` are different text and the same film.

## Ambiguous: three matches were already in hand

`Hannibal`, `Resident Evil: The Final Chapter` and `Resident Evil: Afterlife` came back `no_confident_match` with 1, 4 and 5 candidates — and were reported **unresolved**, which reads as "no such thing" and gives an operator no reason to open the row.

A `no_match` carrying suggestions now reports **ambiguous**: "not confident, you pick". A `no_match` with nothing to offer stays unresolved. The suggestion is still never adopted as the resolution — this changes what we call it, not what we take. This also revives a status that was dead in the batch path: every previous run reported `0 ambiguous`.

## Batch size 200 → 100

Measured against prod: 41 items in 10.7s, 82 in 20.2s — ~0.25s an item against a 60s server deadline. A full 200 would run ~49s in and time out the whole chunk on a bad day. Costs one extra rate-limit unit per 100 items.

`npm test` (195), lint, typecheck, build pass. Playbook updated.