### PR TITLE
A way to throw a build away

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -144,6 +144,14 @@ dropped, struck through, and one `x` puts them back.
 Reference marks, currency amounts and footnote daggers are stripped per row regardless, since none of
 them is ever part of a title.
 
+### Discarding a build
+
+A reload does not clear the builder — a draft is restored precisely so a reload can't destroy one — so
+**Discard build** in the toolbar is the way out, shown only while there are unsaved changes. It confirms
+first, then returns the list to the items the pitch actually holds (or empties it, if there are none) and
+clears the draft. A pasted **Replace all & resolve** does the same thing in passing when the intent is to
+start over from new text.
+
 ### Duplicates
 
 Two checks, because they catch different things. Pasting again skips lines already on the list and says

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -1,5 +1,6 @@
 import { useCallback, useEffect, useRef, useState } from 'react';
 import DataTable from '../../components/DataTable';
+import Modal from '../../components/Modal';
 import { Button, Field, TextArea, TextInput } from '../../components/Form';
 import {
   useImportParse,
@@ -122,6 +123,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   // Restored work is unsaved by definition, so Save is live and the guards are on.
   const [dirty, setDirty] = useState(!!restored.current.draft);
   const [showRestored, setShowRestored] = useState(!!restored.current.draft);
+  const [confirmDiscard, setConfirmDiscard] = useState(false);
   const [search, setSearch] = useState('');
   const [searchResults, setSearchResults] = useState(null);
   const [urlInput, setUrlInput] = useState('');
@@ -197,6 +199,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   // Two rows pointing at one film. Distinct from the paste-time text check:
   // these arrive from resolution, so only the matched ids expose them.
   const duplicates = duplicateIndices(rows);
+  const savedCount = rowsFromItems(items).length;
   const focusedRow = rows[focus];
   const prefill = focusedRow ? queryFor(focusedRow).title : '';
 
@@ -607,6 +610,26 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     setDirty(true);
   }
 
+  /**
+   * Throw the build away and go back to what the pitch actually holds.
+   *
+   * Reloading doesn't do this — a draft is restored precisely so a reload
+   * can't destroy it — and until there was a control that said so, the only
+   * ways out were a pasted Replace or closing the tab.
+   */
+  function discardBuild() {
+    setRows(rowsFromItems(items));
+    clearDraft(pitchId);
+    restored.current.draft = null;
+    setShowRestored(false);
+    setStaleWarning(false);
+    setDirty(false);
+    setFocus(0);
+    setShowPaste(rowsFromItems(items).length === 0);
+    setConfirmDiscard(false);
+    setNote({ ok: true, text: 'Build discarded. Showing the pitch\u2019s saved items.' });
+  }
+
   async function save() {
     // Guard the operation, not the button. Save is reachable from the `s`
     // shortcut too, which is how a TVSeries reached a Movie pitch after the
@@ -937,6 +960,11 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
           </Button>
           <div className="ml-auto flex items-center gap-2">
             {dirty && <span className="text-xs text-amber-600">unsaved changes</span>}
+            {dirty && (
+              <Button disabled={!!busy} onClick={() => setConfirmDiscard(true)}>
+                Discard build
+              </Button>
+            )}
             <Button
               variant="primary"
               onClick={save}
@@ -959,6 +987,28 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
           {busy === 'rechecking' ? 'Re-checking pending rows on the 60s deadline…' : `${busy}…`}
         </div>
       )}
+
+      <Modal
+        open={confirmDiscard}
+        onClose={() => setConfirmDiscard(false)}
+        title="Discard this build?"
+        description={`${counts.kept} row(s) on screen have not been saved to the pitch.`}
+        footer={
+          <>
+            <Button onClick={() => setConfirmDiscard(false)}>Keep working</Button>
+            <Button variant="danger" onClick={discardBuild}>
+              Discard build
+            </Button>
+          </>
+        }
+      >
+        <p className="text-sm text-gray-600">
+          {savedCount === 0
+            ? 'The pitch has no saved items, so this empties the list and you can start from a fresh paste.'
+            : `The pitch keeps the ${savedCount} item(s) it already holds — the list goes back to those.`}{' '}
+          This cannot be undone.
+        </p>
+      </Modal>
 
       {/* Paste box */}
       {showPaste && !readOnly && (

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -665,3 +665,53 @@ describe('builder — the same item twice', () => {
     expect(sent[0].thing_id).toBe('movie_alien_1979');
   });
 });
+
+describe('builder — discarding a build', () => {
+  const drafted = [
+    { raw_text: 'Alien', thing_id: 'movie_alien_1979', status: 'resolved', candidates: [], match: { title: 'Alien', type: 'Movie', year: 1979 }, note: '', dropped: false, confidence: 1, reason: null },
+  ];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+    sessionStorage.setItem('pitchDraft:p_d', JSON.stringify({ v: 1, savedAt: Date.now(), rows: drafted }));
+  });
+
+  it('asks first, and keeps the build if the answer is no', () => {
+    renderWithProviders(<PitchBuilder pitchId="p_d" thingType="Movie" items={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /discard build/i }));
+    fireEvent.click(screen.getByRole('button', { name: /keep working/i }));
+
+    expect(screen.getAllByText('Alien').length).toBeGreaterThan(0);
+    expect(sessionStorage.getItem('pitchDraft:p_d')).toBeTruthy();
+  });
+
+  it('clears the rows and the draft, so a reload cannot bring them back', async () => {
+    renderWithProviders(<PitchBuilder pitchId="p_d" thingType="Movie" items={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /discard build/i }));
+    // Two buttons now read "Discard build" — the toolbar's and the modal's.
+    const inModal = screen.getAllByRole('button', { name: /^discard build$/i });
+    fireEvent.click(inModal[inModal.length - 1]);
+
+    await vi.waitFor(() => expect(screen.queryByText('Alien')).toBeNull());
+    expect(sessionStorage.getItem('pitchDraft:p_d')).toBeNull();
+    expect(screen.queryByText(/unsaved changes/i)).toBeNull();
+  });
+
+  it('goes back to the items the pitch holds, not to nothing', async () => {
+    const saved = [{ position: 1, thing_id: 'movie_jaws_1975', thing_metadata: { title: 'Jaws', year: 1975 }, thing_type_actual: 'Movie', raw_text: 'Jaws' }];
+    renderWithProviders(<PitchBuilder pitchId="p_d" thingType="Movie" items={saved} />);
+    fireEvent.click(screen.getByRole('button', { name: /discard build/i }));
+    const inModal = screen.getAllByRole('button', { name: /^discard build$/i });
+    fireEvent.click(inModal[inModal.length - 1]);
+
+    await vi.waitFor(() => expect(screen.getAllByText('Jaws').length).toBeGreaterThan(0));
+    expect(screen.queryByText('Alien')).toBeNull();
+  });
+
+  it('offers nothing to discard on a clean build', () => {
+    sessionStorage.clear();
+    renderWithProviders(<PitchBuilder pitchId="p_d" thingType="Movie" items={[]} />);
+    expect(screen.queryByRole('button', { name: /discard build/i })).toBeNull();
+  });
+});


### PR DESCRIPTION
Asked how to discard all rows, and there was no good answer. Persisting drafts closed one hole and opened another: a reload no longer destroys a build, which also means a reload is no longer how you abandon one.

Before this, the only ways out were a pasted **Replace all & resolve** — which needs text you may not want to type — or closing the tab, which is not a control anyone should have to discover.

## What changes

**Discard build**, beside the unsaved-changes marker in the toolbar. Shown only while there's something to lose. Confirms first, naming the row count.

It returns the list to the items the pitch actually holds, not to nothing — discarding a build shouldn't also discard what was already saved. The confirmation says which of the two will happen. The draft is cleared, so a reload can't bring the rows back.

`npm test` (199), lint, typecheck, build pass. Playbook updated.