### PR TITLE
Name both rows in a duplicate, not just the later one

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -156,9 +156,14 @@ start over from new text.
 
 Two checks, because they catch different things. Pasting again skips lines already on the list and says
 how many — a build survives a reload now, so a re-paste lands on rows that are still there. Separately,
-two rows that *resolved* to the same thing are reported by row number with a one-click drop, and block
-the save the way a type mismatch does. Only the resolved ids expose those; the text check cannot see
-them.
+two rows that *resolved* to the same thing block the save the way a type mismatch does. Only the resolved
+ids expose those; the text check cannot see them.
+
+Both rows in a collision are named, with the film they landed on — not just the later one. The later row
+is not reliably the wrong one: a mis-picked candidate on row 17 collided with the correct row 31, and
+naming only 31 would have had the operator delete the film and keep the mistake. Deciding which match is
+wrong needs both rows in view, so the strip offers a jump to the first and a drop of the rest, and does
+not choose.
 
 ### Ambiguous vs unresolved
 

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -26,6 +26,7 @@ import {
   queryFor,
   dedupeAgainst,
   duplicateIndices,
+  duplicateGroups,
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
@@ -198,6 +199,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     .filter(({ row }) => !row.dropped && row.thing_id && !typeMatchesPitch(row.match?.type, thingType));
   // Two rows pointing at one film. Distinct from the paste-time text check:
   // these arrive from resolution, so only the matched ids expose them.
+  const dupeGroups = duplicateGroups(rows);
   const duplicates = duplicateIndices(rows);
   const savedCount = rowsFromItems(items).length;
   const focusedRow = rows[focus];
@@ -856,24 +858,37 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         </div>
       )}
 
-      {duplicates.length > 0 && (
-        <div className="rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
-          <span className="font-medium">
-            Row {duplicates.map(i => i + 1).join(', ')} {duplicates.length === 1 ? 'is' : 'are'} already on
-            this list.
-          </span>{' '}
-          The same film twice reads as carelessness on the pitch itself. Dropping keeps the first of each.
-          <button
-            onClick={() => {
-              const drop = new Set(duplicates);
-              setRows(rs => rs.map((r, i) => (drop.has(i) ? { ...r, dropped: true } : r)));
-              setDirty(true);
-            }}
-            disabled={readOnly}
-            className="ml-2 font-medium underline decoration-dotted underline-offset-2 disabled:no-underline disabled:opacity-50"
-          >
-            Drop {duplicates.length === 1 ? 'it' : `all ${duplicates.length}`}
-          </button>
+      {dupeGroups.length > 0 && (
+        <div className="space-y-2 rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+          {dupeGroups.map(group => (
+            <div key={group.thing_id}>
+              <span className="font-medium">
+                Rows {group.indices.map(i => i + 1).join(' and ')} both point at{' '}
+                {group.title ? `“${group.title}”` : 'the same item'}.
+              </span>{' '}
+              One of them matched the wrong film — check which before dropping either.
+              <button
+                onClick={() => {
+                  setFocus(group.indices[0]);
+                }}
+                className="ml-2 font-medium underline decoration-dotted underline-offset-2"
+              >
+                Go to row {group.indices[0] + 1}
+              </button>
+              {!readOnly && (
+                <button
+                  onClick={() => {
+                    const drop = new Set(group.indices.slice(1));
+                    setRows(rs => rs.map((r, i) => (drop.has(i) ? { ...r, dropped: true } : r)));
+                    setDirty(true);
+                  }}
+                  className="ml-2 font-medium underline decoration-dotted underline-offset-2"
+                >
+                  Drop row {group.indices.slice(1).map(i => i + 1).join(', ')}
+                </button>
+              )}
+            </div>
+          ))}
         </div>
       )}
 

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -643,9 +643,12 @@ describe('builder — the same item twice', () => {
     sessionStorage.setItem('pitchDraft:p_dup', JSON.stringify({ v: 1, savedAt: Date.now(), rows: twice }));
   });
 
-  it('names the repeat and refuses to save it', async () => {
+  it('names both rows and the film, so the wrong one can be found', async () => {
+    // Naming only the later row pointed the operator at the good row: a
+    // mis-picked candidate on an earlier row collided with the correct one,
+    // and "drop the repeat" would have kept the mistake.
     renderWithProviders(<PitchBuilder pitchId="p_dup" thingType="Movie" items={[]} />);
-    expect(screen.getByText(/Row 2 is already on this list/i)).toBeTruthy();
+    expect(screen.getByText(/Rows 1 and 2 both point at “Alien”/i)).toBeTruthy();
 
     // The `s` shortcut bypasses the disabled button, so guard the operation.
     fireEvent.keyDown(window, { key: 's' });
@@ -655,9 +658,9 @@ describe('builder — the same item twice', () => {
 
   it('drops the repeat and keeps the first, then saves', async () => {
     renderWithProviders(<PitchBuilder pitchId="p_dup" thingType="Movie" items={[]} />);
-    fireEvent.click(screen.getByRole('button', { name: /^Drop it$/i }));
+    fireEvent.click(screen.getByRole('button', { name: /^Drop row 2$/i }));
 
-    expect(screen.queryByText(/already on this list/i)).toBeNull();
+    expect(screen.queryByText(/both point at/i)).toBeNull();
     fireEvent.click(screen.getByRole('button', { name: /save items/i }));
     await vi.waitFor(() => expect(client.put).toHaveBeenCalled());
     const sent = client.put.mock.calls[0][1].items;

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -17,6 +17,7 @@ import {
   queryFor,
   dedupeAgainst,
   duplicateIndices,
+  duplicateGroups,
   summarize,
   toBatchPayload,
   toItemsPayload,
@@ -572,5 +573,37 @@ describe('duplicates', () => {
   it('ignores a dropped repeat', () => {
     const rows = [row('Alien', 'movie_alien_1979'), { ...row('Alien', 'movie_alien_1979'), dropped: true }];
     expect(duplicateIndices(rows)).toEqual([]);
+  });
+});
+
+describe('duplicateGroups — which row is wrong is not ours to decide', () => {
+  const row = (raw, thingId, title) => ({
+    raw_text: raw, thing_id: thingId, status: thingId ? 'resolved' : 'unresolved',
+    candidates: [], match: thingId ? { title, type: 'Movie', year: null } : null,
+    note: '', dropped: false, confidence: null, reason: null,
+  });
+
+  it('reports every row in the group and what they landed on', () => {
+    // Row 17 mis-picked and collided with row 31, the correct one. Reporting
+    // only 31 sent the operator to delete the right film.
+    const rows = [
+      row('16 Hannibal 2001', 'movie_the_silence_of_the_lambs_1991', 'The Silence of the Lambs'),
+      row('17 Alien: Romulus 2024', 'movie_alien_romulus_2024', 'Alien: Romulus'),
+      row('30 The Silence of the Lambs 1991', 'movie_the_silence_of_the_lambs_1991', 'The Silence of the Lambs'),
+    ];
+    expect(duplicateGroups(rows)).toEqual([
+      { thing_id: 'movie_the_silence_of_the_lambs_1991', title: 'The Silence of the Lambs', indices: [0, 2] },
+    ]);
+  });
+
+  it('still knows which are the repeats', () => {
+    const rows = [
+      row('a', 'movie_x', 'X'), row('b', 'movie_x', 'X'), row('c', 'movie_x', 'X'), row('d', 'movie_y', 'Y'),
+    ];
+    expect(duplicateIndices(rows)).toEqual([1, 2]);
+  });
+
+  it('reports nothing when every row is its own film', () => {
+    expect(duplicateGroups([row('a', 'movie_x', 'X'), row('b', 'movie_y', 'Y')])).toEqual([]);
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -574,21 +574,47 @@ export function dedupeAgainst(
   return { rows, skipped: incoming.length - rows.length };
 }
 
+/** Rows that landed on one thing, and what that thing is. */
+export interface DuplicateGroup {
+  thing_id: string;
+  title: string | null;
+  /** Every row in the group, in list order — not just the repeats. */
+  indices: number[];
+}
+
 /**
- * Kept rows that resolved to the same thing, beyond the first of each.
+ * Kept rows that resolved to the same thing.
  *
  * The text-level check can't see these: two different lines ("Alien" and
  * "Alien (1979)") resolving to one film is the same item twice on the list.
+ *
+ * Every row in the group is reported, not only the later ones, because the
+ * later row is not reliably the wrong one. A mis-picked candidate on row 17
+ * collided with the correct row 31, and naming only 31 pointed the operator
+ * at the good row: dropping it would have kept the mistake and deleted the
+ * film. Which row is wrong is a judgement about the match, so it belongs to
+ * whoever can see both.
  */
-export function duplicateIndices(rows: BuilderRow[]): number[] {
-  const first = new Map<string, number>();
-  const dupes: number[] = [];
+export function duplicateGroups(rows: BuilderRow[]): DuplicateGroup[] {
+  const byThing = new Map<string, number[]>();
   rows.forEach((row, i) => {
     if (row.dropped || !row.thing_id) return;
-    if (first.has(row.thing_id)) dupes.push(i);
-    else first.set(row.thing_id, i);
+    const at = byThing.get(row.thing_id);
+    if (at) at.push(i);
+    else byThing.set(row.thing_id, [i]);
   });
-  return dupes;
+  return [...byThing.entries()]
+    .filter(([, indices]) => indices.length > 1)
+    .map(([thing_id, indices]) => ({
+      thing_id,
+      title: rows[indices[0]].match?.title || null,
+      indices,
+    }));
+}
+
+/** The repeats alone — every row in a group but the first. */
+export function duplicateIndices(rows: BuilderRow[]): number[] {
+  return duplicateGroups(rows).flatMap(g => g.indices.slice(1));
 }
 
 /** Counts for the builder's summary strip. */


### PR DESCRIPTION
Found in use, on the run that otherwise worked: 40 rows, 37 resolved, 3 ambiguous picked by hand — then Save refused with

> Row 31 is already on this list. … Dropping keeps the first of each. **Drop it**

Row 31 was **The Silence of the Lambs**, the correct row. An earlier row — the just-picked candidate on row 17, Hannibal — had landed on the same film. Following the instruction would have deleted the right film and kept the mis-match in its place.

## The bug

`duplicateIndices` reported every row in a group *but the first*, and the copy promised dropping "keeps the first of each". Both assume the earlier row is the good one. Nothing supports that — and the case where it's false is exactly the case that produces the collision, since a fresh mis-pick lands wherever the operator happened to be.

## The fix

A collision now names **every row in the group and the film they landed on**:

> Rows 17 and 31 both point at "The Silence of the Lambs". One of them matched the wrong film — check which before dropping either. · Go to row 17 · Drop row 31

Deciding which match is wrong needs both rows in view, so the strip offers the jump and the drop, and doesn't pretend to know. The save stays blocked either way.

`npm test` (202), lint, typecheck, build pass. Playbook updated.