### PR TITLE
Flag a match that agrees with nothing on its line

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -165,6 +165,17 @@ naming only 31 would have had the operator delete the film and keep the mistake.
 wrong needs both rows in view, so the strip offers a jump to the first and a drop of the rest, and does
 not choose.
 
+### Matches worth a second look
+
+`matchConcern()` flags a resolved row whose match agrees with nothing on the line it came from: a title
+sharing no word of three letters or more, or a year more than one out. It blocks nothing — a real match
+often shifts a year between a box-office table and the registry — but it colours the cell amber and lists
+the row above the table.
+
+It exists because the matcher offered *The Silence of the Lambs* (1991) as its **only** suggestion for
+`Hannibal` (2001), and a single suggestion presented alone reads as the answer. Both disagreements were
+already in the row. Verified against every resolved row of the 40-film build: one flag, no false ones.
+
 ### Ambiguous vs unresolved
 
 A server `no_match` that ships suggestions is reported **ambiguous** — "not confident, you pick" — and

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -27,6 +27,7 @@ import {
   dedupeAgainst,
   duplicateIndices,
   duplicateGroups,
+  matchConcern,
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
@@ -200,6 +201,11 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
   // Two rows pointing at one film. Distinct from the paste-time text check:
   // these arrive from resolution, so only the matched ids expose them.
   const dupeGroups = duplicateGroups(rows);
+  // Matches that agree with nothing on the line they came from. Advisory: a
+  // real match often shifts a year, so this informs rather than blocks.
+  const suspect = rows
+    .map((row, i) => ({ i, why: matchConcern(row) }))
+    .filter(({ why }) => why);
   const duplicates = duplicateIndices(rows);
   const savedCount = rowsFromItems(items).length;
   const focusedRow = rows[focus];
@@ -750,10 +756,11 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       header: 'Resolved to',
       render: row =>
         row.match?.title ? (
-          <span className="text-gray-700">
+          <span className={matchConcern(row) ? 'text-amber-700' : 'text-gray-700'}>
             {row.match.title}
             {row.match.year != null && <span className="ml-1 text-gray-400 tabular-nums">{row.match.year}</span>}
             {row.match.type && <span className="ml-1 text-gray-400">· {row.match.type}</span>}
+            {matchConcern(row) && <span className="ml-1" title={matchConcern(row)}>⚠</span>}
           </span>
         ) : row.thing_id ? (
           <code className="text-[11px] text-gray-500">{row.thing_id}</code>
@@ -855,6 +862,17 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
           Every item on a list must match the list's type — the database rejects a mismatch when the target
           claims the draft, so this would fail on them rather than on us. Re-match or drop{' '}
           {mismatched.length === 1 ? 'it' : 'them'} before saving.
+        </div>
+      )}
+
+      {suspect.length > 0 && (
+        <div className="rounded border border-amber-200 bg-amber-50 p-2 text-xs text-amber-800">
+          <span className="font-medium">
+            Worth a look: row {suspect.map(sr => sr.i + 1).join(', ')}.
+          </span>{' '}
+          {suspect.map(sr => `Row ${sr.i + 1} — ${sr.why}`).join('. ')}. A match can legitimately re-date or
+          rename an item, so this blocks nothing — but a match that agrees with nothing on the line usually
+          means the matcher offered the closest thing it had rather than the right one.
         </div>
       )}
 

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -18,6 +18,7 @@ import {
   dedupeAgainst,
   duplicateIndices,
   duplicateGroups,
+  matchConcern,
   summarize,
   toBatchPayload,
   toItemsPayload,
@@ -605,5 +606,103 @@ describe('duplicateGroups — which row is wrong is not ours to decide', () => {
 
   it('reports nothing when every row is its own film', () => {
     expect(duplicateGroups([row('a', 'movie_x', 'X'), row('b', 'movie_y', 'Y')])).toEqual([]);
+  });
+});
+
+describe('matchConcern — a match that agrees with nothing', () => {
+  // Rows must come from a real block paste, or queryFor falls back to the
+  // per-row cleaner and the comparison is made against a string production
+  // never sees — which would let a broken cleaner pass this suite.
+  const BLOCK = [
+    '1 It 2017 $719,766,009 [1][2]',
+    '7 Jaws 1975 $495,201,848 [13][14]',
+    '8 It Chapter Two 2019 $473,123,154 [15][16]',
+    '16 Hannibal 2001 $351,692,268 [31][32]',
+    '19 The Conjuring 2 2016 $322,811,702 [37][38]',
+    '20 The Conjuring 2013 $320,415,166 [39][40]',
+    '26 A Quiet Place Part II 2020 $297,372,261 [51][52]',
+    '27 Five Nights at Freddy\u2019s 2023 $297,144,130 [53][54]',
+    '30 The Silence of the Lambs 1991 $275,726,716 [59][60]',
+    '33 A Quiet Place: Day One 2024 $261,907,653 [65][66]',
+    '37 Us 2019 $256,071,218 [73][74]',
+    '5 Obsession \u2020 2026 $501,596,715 [9][10]',
+  ];
+  const built = rowsFromParsed(normalizeParsed(BLOCK));
+  const at = raw => built[BLOCK.indexOf(raw)];
+  const paste = raw => at(raw);
+  const matched = (raw, title, year) => ({
+    ...at(raw),
+    thing_id: 'movie_x',
+    status: 'resolved',
+    match: { title, type: 'Movie', year },
+  });
+
+  it('is comparing against the cleaned title, not the pasted line', () => {
+    expect(queryFor(at('16 Hannibal 2001 $351,692,268 [31][32]'))).toEqual({
+      title: 'Hannibal', year: 2001, header: false,
+    });
+  });
+
+  it('flags the one that went wrong in production', () => {
+    // The matcher offered The Silence of the Lambs as its only suggestion for
+    // Hannibal, so the operator picked the one thing on offer. Different name,
+    // ten years out — the row knew both.
+    const why = matchConcern(matched('16 Hannibal 2001 $351,692,268 [31][32]', 'The Silence of the Lambs', 1991));
+    expect(why).toMatch(/The Silence of the Lambs/);
+    expect(why).toMatch(/2001.*1991/);
+  });
+
+  it('accepts a year of drift between a table and the registry', () => {
+    // Real match from the same run: the table dates it 2020, the registry 2021.
+    expect(matchConcern(matched('26 A Quiet Place Part II 2020 $297,372,261 [51][52]', 'A Quiet Place Part II', 2021))).toBeNull();
+  });
+
+  it('accepts a sequel or a re-pointed title that still shares the name', () => {
+    expect(matchConcern(matched('19 The Conjuring 2 2016 $322,811,702 [37][38]', 'The Conjuring 2', 2016))).toBeNull();
+    expect(matchConcern(matched('8 It Chapter Two 2019 $473,123,154 [15][16]', 'It Chapter Two', 2019))).toBeNull();
+  });
+
+  it('says nothing about a row that has not resolved', () => {
+    expect(matchConcern(paste('16 Hannibal 2001 $351,692,268 [31][32]'))).toBeNull();
+  });
+
+  it('leaves the whole clean run clean', () => {
+    // Every resolved row from the 40-film build. One false positive here would
+    // be an amber warning on a correct match, which teaches operators to skip
+    // the warnings.
+    const clean = [
+      ['1 It 2017 $719,766,009 [1][2]', 'It', 2017],
+      ['7 Jaws 1975 $495,201,848 [13][14]', 'Jaws', 1975],
+      ['20 The Conjuring 2013 $320,415,166 [39][40]', 'The Conjuring', 2013],
+      ['27 Five Nights at Freddy’s 2023 $297,144,130 [53][54]', "Five Nights at Freddy's", 2023],
+      ['30 The Silence of the Lambs 1991 $275,726,716 [59][60]', 'The Silence of the Lambs', 1991],
+      ['33 A Quiet Place: Day One 2024 $261,907,653 [65][66]', 'A Quiet Place: Day One', 2024],
+      ['37 Us 2019 $256,071,218 [73][74]', 'Us', 2019],
+      ['5 Obsession † 2026 $501,596,715 [9][10]', 'Obsession', 2026],
+    ];
+    // "The Conjuring" is a substring of "The Conjuring 2": the pair has to stay
+    // clean in both directions, or a franchise flags itself.
+    expect(matchConcern(matched(BLOCK[5], 'The Conjuring', 2013))).toBeNull();
+    for (const [raw, title, year] of clean) {
+      expect(matchConcern(matched(raw, title, year)), raw).toBeNull();
+    }
+  });
+});
+
+describe('tableQueries — a table the operator re-sorted', () => {
+  it('still reads the ranks when the order is scrambled', () => {
+    // Sorted by year, so the rank column runs 30, 7, 1 — no less a rank column.
+    const q = tableQueries([
+      '30 The Silence of the Lambs 1991 $275,726,716 [59][60]',
+      '7 Jaws 1975 $495,201,848 [13][14]',
+      '1 It 2017 $719,766,009 [1][2]',
+    ]);
+    expect(q.map(r => r.title)).toEqual(['The Silence of the Lambs', 'Jaws', 'It']);
+  });
+
+  it('does not invent a rank column for number-titled films', () => {
+    // Descending, and no money or reference columns to corroborate.
+    expect(tableQueries(['300 Rise of an Empire', '28 Days Later', '12 Monkeys']).map(r => r.title))
+      .toEqual(['300 Rise of an Empire', '28 Days Later', '12 Monkeys']);
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -377,12 +377,12 @@ export interface RowQuery {
 export function tableQueries(rawTexts: string[]): RowQuery[] {
   const texts = (rawTexts || []).map(t => t || '');
 
-  // A rank column: most rows open with a bare integer and those integers climb.
-  // Ascending alone is too weak — 12 Angry Men, 28 Days Later, 300 climb by
-  // accident — so it also takes one of two corroborations: the numbers step by
-  // one, or the rest of the block is visibly tabular. The second matters,
-  // because an operator who deletes a few rows leaves gaps in the numbering
-  // and the sequence test alone would then hand the ranks to the matcher.
+  // A rank column: most rows open with a bare integer, corroborated either by
+  // the numbers stepping cleanly up or by the rest of the block being visibly
+  // tabular. Ascending alone is too weak — 12 Angry Men, 28 Days Later, 300
+  // climb by accident — and the sequence alone is too strict, since deleting a
+  // few rows leaves gaps and re-sorting the table scrambles the order outright.
+  // Money and reference columns are what a list of number-titled films lacks.
   const ranks = texts.map(t => {
     const m = t.match(RANK_CELL);
     return m ? Number(m[1]) : null;
@@ -394,8 +394,11 @@ export function tableQueries(rawTexts: string[]): RowQuery[] {
   const rankColumn =
     present.length >= 3 &&
     present.length >= texts.length * 0.6 &&
-    ascending &&
-    (steps >= (present.length - 1) * 0.8 || columnar >= texts.length * 0.6);
+    // Either corroboration is enough on its own. Ascending order is not
+    // required when the block is visibly tabular: an operator who re-sorts a
+    // table by year before copying scrambles the ranks, and they are no less
+    // ranks for it.
+    ((ascending && steps >= (present.length - 1) * 0.8) || columnar >= texts.length * 0.6);
 
   return texts.map((raw, i) => {
     // A heading only reads as one against the table it heads: every item row
@@ -572,6 +575,50 @@ export function dedupeAgainst(
     rows.push(row);
   }
   return { rows, skipped: incoming.length - rows.length };
+}
+
+/** Reduce a title to what a comparison should care about. */
+function compareKey(title: string): string {
+  return (title || '')
+    .toLowerCase()
+    .replace(/[\u2018\u2019']/g, '')
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim();
+}
+
+/**
+ * Whether a resolved row disagrees with the line it came from, and how.
+ *
+ * Advisory, never blocking — a legitimate match often shifts a year (a film
+ * dated 2020 by a box-office table and 2021 by the registry) and re-points a
+ * title. What it catches is the match that agrees with nothing: "Hannibal"
+ * (2001) resolved to "The Silence of the Lambs" (1991), which the matcher had
+ * offered as its only suggestion, so the operator picked the one thing on
+ * offer. Both signals were sitting in the row at the time.
+ */
+export function matchConcern(row: BuilderRow): string | null {
+  if (row.dropped || !row.thing_id || !row.match) return null;
+  const asked = queryFor(row);
+  const reasons: string[] = [];
+
+  const wanted = compareKey(asked.title);
+  const got = compareKey(row.match.title || '');
+  if (wanted && got && wanted !== got && !got.includes(wanted) && !wanted.includes(got)) {
+    // Sequels and re-releases share words with what was asked for; a match
+    // sharing none of them is a different work.
+    const words = new Set(wanted.split(' ').filter(w => w.length >= 3));
+    const shared = got.split(' ').some(w => w.length >= 3 && words.has(w));
+    if (!shared) reasons.push(`matched “${row.match.title}”`);
+  }
+
+  const gotYear = Number(row.match.year);
+  // One year of drift is ordinary between a table and a registry; a decade is
+  // a different film.
+  if (asked.year && Number.isFinite(gotYear) && Math.abs(asked.year - gotYear) > 1) {
+    reasons.push(`the line says ${asked.year}, the match is ${gotYear}`);
+  }
+
+  return reasons.length ? reasons.join('; ') : null;
 }
 
 /** Rows that landed on one thing, and what that thing is. */


### PR DESCRIPTION
Row 17 of the 40-film build, confirmed in use: **Hannibal (2001) resolved to The Silence of the Lambs (1991)**. The matcher offered that as its *only* suggestion, and one suggestion presented alone reads as the answer — so it was picked. The mistake only surfaced at save time, as a duplicate against the row that held the real film.

## What changes

`matchConcern()` flags a resolved row whose match agrees with nothing on the line it came from:

- the titles share no word of three letters or more, **or**
- the years differ by more than one

Both were true here, and both were sitting in the row at the time. The cell goes amber with the reason on hover, and the rows are listed above the table.

**It blocks nothing.** A legitimate match often shifts a year — A Quiet Place Part II is 2020 in the box-office table and 2021 in the registry — and a warning that cries wolf is worse than no warning. Verified against every resolved row of the 40-film build: one flag, no false ones.

## Also: rank detection accepts a re-sorted table

Caught by writing the test fixture. Detection required *ascending* numbers, which a table sorted by year before copying doesn't have — but the money and reference columns already prove it's a table, so either corroboration is now enough on its own. A list of number-titled films (`300 Rise of an Empire`, `28 Days Later`, `12 Monkeys`) has neither and is still left alone.

The test fixture now builds rows through a real block paste rather than hand-assembling them, because the old helper compared against a string production never produces — a broken cleaner would have passed.

`npm test` (210), lint, typecheck, build pass. Playbook updated.