### PR TITLE
Align the year tolerance with the server, and correct a stale claim

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -168,12 +168,15 @@ not choose.
 ### Matches worth a second look
 
 `matchConcern()` flags a resolved row whose match agrees with nothing on the line it came from: a title
-sharing no word of three letters or more, or a year more than one out. It blocks nothing — a real match
+sharing no word of three letters or more, or a year more than two out. Two years is deliberately the same
+window the server's suggestion filter keeps (listgem-platform#564) — flagging inside it would only
+contradict a judgement the server has already made. It blocks nothing — a real match
 often shifts a year between a box-office table and the registry — but it colours the cell amber and lists
 the row above the table.
 
 It exists because the matcher offered *The Silence of the Lambs* (1991) as its **only** suggestion for
-`Hannibal` (2001), and a single suggestion presented alone reads as the answer. Both disagreements were
+`Hannibal` (2001), and a single suggestion presented alone reads as the answer. The registry did not hold
+Hannibal at the time; `no_confident_match` was the right verdict, and only the suggestion was wrong. Both disagreements were
 already in the row. Verified against every resolved row of the 40-film build: one flag, no false ones.
 
 ### Ambiguous vs unresolved

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -652,9 +652,20 @@ describe('matchConcern — a match that agrees with nothing', () => {
     expect(why).toMatch(/2001.*1991/);
   });
 
-  it('accepts a year of drift between a table and the registry', () => {
+  it('accepts the drift the server itself tolerates', () => {
     // Real match from the same run: the table dates it 2020, the registry 2021.
-    expect(matchConcern(matched('26 A Quiet Place Part II 2020 $297,372,261 [51][52]', 'A Quiet Place Part II', 2021))).toBeNull();
+    const row = '26 A Quiet Place Part II 2020 $297,372,261 [51][52]';
+    expect(matchConcern(matched(row, 'A Quiet Place Part II', 2021))).toBeNull();
+    // Two years is the window the server's suggestion filter keeps
+    // (listgem-platform#564); flagging inside it would only contradict it.
+    expect(matchConcern(matched(row, 'A Quiet Place Part II', 2022))).toBeNull();
+    expect(matchConcern(matched(row, 'A Quiet Place Part II', 2018))).toBeNull();
+  });
+
+  it('still catches the gap a franchise sibling opens', () => {
+    // 15 years, the Resident Evil mis-pick; 10, the Hannibal one.
+    expect(matchConcern(matched('26 A Quiet Place Part II 2020 $297,372,261 [51][52]', 'A Quiet Place', 2023)))
+      .toMatch(/2020.*2023/);
   });
 
   it('accepts a sequel or a re-pointed title that still shares the name', () => {

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -47,8 +47,10 @@ export interface Candidate {
   score: number | null;
   /**
    * False for a federated hit that exists in TMDB/Spotify/Books but not in our
-   * registry. Those carry no thing_id and cannot be attached to a pitch until
-   * there's a way to materialise a Thing without a list (listgem-platform#550).
+   * registry. Those carry no thing_id, and picking one materialises it through
+   * POST /things/resolve-or-create before attaching (listgem-platform#550,
+   * shipped) — so attaching is not evidence the registry already held it. The
+   * builder reports which of the two happened; believe that, not the outcome.
    */
   in_registry: boolean;
   /** 'local' for a registry hit, otherwise the external source that found it. */
@@ -577,6 +579,9 @@ export function dedupeAgainst(
   return { rows, skipped: incoming.length - rows.length };
 }
 
+/** Years of drift between a source line and a match that mean nothing. */
+const YEAR_TOLERANCE = 2;
+
 /** Reduce a title to what a comparison should care about. */
 function compareKey(title: string): string {
   return (title || '')
@@ -612,9 +617,11 @@ export function matchConcern(row: BuilderRow): string | null {
   }
 
   const gotYear = Number(row.match.year);
-  // One year of drift is ordinary between a table and a registry; a decade is
-  // a different film.
-  if (asked.year && Number.isFinite(gotYear) && Math.abs(asked.year - gotYear) > 1) {
+  // Two years, matching the window the server's suggestion filter now keeps
+  // (listgem-platform#564). Release dates vary by region and a registry can
+  // date a film by its festival run; a decade is a different film. Disagreeing
+  // with the server here would only flag matches it has already judged fine.
+  if (asked.year && Number.isFinite(gotYear) && Math.abs(asked.year - gotYear) > YEAR_TOLERANCE) {
     reasons.push(`the line says ${asked.year}, the match is ${gotYear}`);
   }
 


### PR DESCRIPTION
Follow-up to the backend team's response on listgem-platform#563 (fixed by their PR #564).

## Year tolerance 1 → 2

Their filter now drops suggestions more than **±2 years** from the requested year. Our amber flag fired at more than **1**, so once #564 merges the only rows it could add over the server are ones the server has explicitly judged acceptable. A warning that contradicts the system it guards is a warning operators learn to skip.

The gaps this exists to catch are 10 years (Hannibal) and 15 (Resident Evil), so nothing real is lost.

## A stale comment, and a correction I owe them

The note on `in_registry` said a federated hit "cannot be attached to a pitch until there's a way to materialise a Thing without a list (listgem-platform#550)". That shipped — picking a federated result now creates the Thing via `POST /things/resolve-or-create` and attaches it.

I relied on the stale version when filing #563, claiming the correct films were "already in the registry" because the operator could attach them. They weren't; they were created from TMDB results on attach, which means `no_confident_match` was the *correct* verdict and only the suggestion was wrong. The builder distinguishes the two cases in its own success message — "Added X to the registry and attached it" versus "was already in the registry" — so the evidence was on screen and I inferred instead of asking.

Comment posted on #563 with the correction.

`npm test` (211), lint, typecheck, build pass. Playbook updated.