### PR TITLE
A missing year is not a disagreement

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -170,7 +170,10 @@ not choose.
 `matchConcern()` flags a resolved row whose match agrees with nothing on the line it came from: a title
 sharing no word of three letters or more, or a year more than two out. Two years is deliberately the same
 window the server's suggestion filter keeps (listgem-platform#564) — flagging inside it would only
-contradict a judgement the server has already made. It blocks nothing — a real match
+contradict a judgement the server has already made.
+
+The year rule is theirs exactly, both halves: **flagged only when both years are known and they disagree
+by more than two.** A line with no year, or a match with no year, says nothing — so this says nothing. It blocks nothing — a real match
 often shifts a year between a box-office table and the registry — but it colours the cell amber and lists
 the row above the table.
 

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -717,3 +717,34 @@ describe('tableQueries — a table the operator re-sorted', () => {
       .toEqual(['300 Rise of an Empire', '28 Days Later', '12 Monkeys']);
   });
 });
+
+describe('matchConcern — a missing year is not a disagreement', () => {
+  const BLOCK = [
+    '16 Hannibal 2001 $351,692,268 [31][32]',
+    '7 Jaws 1975 $495,201,848 [13][14]',
+    '1 It 2017 $719,766,009 [1][2]',
+  ];
+  const built = rowsFromParsed(normalizeParsed(BLOCK));
+  const withMatchYear = year => ({
+    ...built[0],
+    thing_id: 'movie_x',
+    status: 'resolved',
+    match: { title: 'Hannibal', type: 'Movie', year },
+  });
+
+  // The server keeps a suggestion when the year is supplied but the candidate
+  // has none (listgem-platform#563). Number(null) and Number('') are 0, and 0
+  // is finite, so the naive check called that a 2001-year disagreement.
+  it.each([null, undefined, '', 'unknown'])('says nothing when the match year is %p', year => {
+    expect(matchConcern(withMatchYear(year))).toBeNull();
+  });
+
+  it('says nothing when the line carried no year', () => {
+    const plain = rowsFromParsed(normalizeParsed(['Hannibal']))[0];
+    expect(matchConcern({ ...plain, thing_id: 'movie_x', status: 'resolved', match: { title: 'Hannibal', type: 'Movie', year: 1991 } })).toBeNull();
+  });
+
+  it('still speaks when both years are known and far apart', () => {
+    expect(matchConcern(withMatchYear(1991))).toMatch(/2001.*1991/);
+  });
+});

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -616,11 +616,18 @@ export function matchConcern(row: BuilderRow): string | null {
     if (!shared) reasons.push(`matched “${row.match.title}”`);
   }
 
-  const gotYear = Number(row.match.year);
-  // Two years, matching the window the server's suggestion filter now keeps
+  // Number(null) and Number('') are both 0, and 0 is finite — so a match with
+  // no year would read as disagreeing by two thousand of them.
+  const rawYear = row.match.year;
+  const gotYear = rawYear === null || rawYear === undefined || rawYear === '' ? NaN : Number(rawYear);
+  // Two years, matching the window the server's suggestion filter keeps
   // (listgem-platform#564). Release dates vary by region and a registry can
   // date a film by its festival run; a decade is a different film. Disagreeing
   // with the server here would only flag matches it has already judged fine.
+  //
+  // Same rule as theirs, both halves: withheld — here, flagged — only when we
+  // know both years and they disagree by more than two. A missing year on
+  // either side says nothing, so it says nothing.
   if (asked.year && Number.isFinite(gotYear) && Math.abs(asked.year - gotYear) > YEAR_TOLERANCE) {
     reasons.push(`the line says ${asked.year}, the match is ${gotYear}`);
   }


### PR DESCRIPTION
Found by reading the backend team's answer on listgem-platform#563 against our own code.

They documented a second no-op in the suggestion filter: a suggestion is **kept** when the year is supplied but the candidate has none. Their rule is "withheld only when we know both years and they disagree by more than two."

Ours didn't match. `Number(null)` and `Number('')` are both `0`, and `0` is finite — so a match carrying no year read as disagreeing with its line by two thousand years and went amber. The guard looked right (`Number.isFinite(gotYear)`) and did the opposite of its intent.

Now flagged only when both years are known and they disagree by more than two — theirs exactly, both halves. Covered for `null`, `undefined`, `''`, an unparseable string, and a source line that carried no year at all.

`npm test` (217), lint, typecheck, build pass. Playbook updated.