### PR TITLE
Mark the fields the target can read

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -191,6 +191,20 @@ correct match already sitting in their candidate lists. When a resolve goes wron
 `search_year` beside `raw_text`; if those two are identical the cleaner did nothing, which is the first
 thing to check.
 
+## What the preview link exposes
+
+`GET /pitches/preview/:token` is public and unauthenticated, and the link is forwardable, so its payload
+is readable by anyone who ends up holding it. Verified against prod on 2026-08-25: no contact details, no
+tokens, no `assigned_to`, no notes, no pitch status, and nothing resembling `verified_method`.
+
+What it *does* carry is every inherited field — `target_name`, `target_org`, the proposed title and
+description, `category`, `source_url` and `source_attribution` — plus each item's `raw_text`. Both intake
+and edit mark these as target-visible, because nothing else in the form said so: an attribution typed as
+`ew`, shorthand while entering a pitch, rendered to the target as “Compiled from ew.”
+
+`raw_text` staying in the payload is worth knowing when pasting from a table — the page renders resolved
+titles, but the pasted line (box-office columns, reference marks and all) is in the response behind it.
+
 ## Verifying against prod
 
 Prod is the only environment, and this feature writes **real people's contact details**. Anything created

--- a/src/pages/concierge/EditDetailsModal.jsx
+++ b/src/pages/concierge/EditDetailsModal.jsx
@@ -24,7 +24,7 @@ const INHERITED = [
   { key: 'proposed_description', label: 'Proposed description', multiline: true },
   { key: 'category', label: 'Category', hint: 'Free text. Copied onto their list.' },
   { key: 'source_url', label: 'Source URL', hint: "The exact page you're rebuilding." },
-  { key: 'source_attribution', label: 'Source attribution', hint: 'Credit line on their list.' },
+  { key: 'source_attribution', label: 'Source attribution', hint: 'Reads “Compiled from …” on the preview. A name, not shorthand.' },
 ];
 
 const FIELDS = [...INTERNAL, ...INHERITED, { key: 'assigned_to', label: 'Assigned to' }];
@@ -112,7 +112,7 @@ export default function EditDetailsModal({ open, pitch, onClose, onSaved }) {
 
       <Section
         title="The list they'll receive"
-        note="Copied into their account when they claim the draft — write it for them, not for us."
+        note="On the preview page from the moment tokens are issued, and copied into their account when they claim. The preview link is public and forwardable — write these for them, not for us."
       />
       {INHERITED.map(renderField)}
     </Modal>

--- a/src/pages/concierge/IntakeModal.jsx
+++ b/src/pages/concierge/IntakeModal.jsx
@@ -28,6 +28,25 @@ function typeOptions(live) {
   return { options, offline: false };
 }
 
+/**
+ * Marks a field whose value is rendered on the public preview page.
+ *
+ * Every one of these reaches anyone the preview link is forwarded to. It was
+ * not visible from the form: a source attribution typed as "ew" — shorthand
+ * for the operator, a credit line to the target — went out reading
+ * "Compiled from ew."
+ */
+function Public() {
+  return (
+    <span
+      className="ml-1 rounded bg-indigo-50 px-1 py-0.5 align-middle text-[10px] font-medium text-indigo-700"
+      title="Rendered on the preview page the target sees"
+    >
+      target sees this
+    </span>
+  );
+}
+
 const EMPTY = {
   target_name: '',
   target_org: '',
@@ -114,7 +133,7 @@ export default function IntakeModal({ open, onClose, onCreated }) {
 
       <div className="grid grid-cols-2 gap-x-4">
         <Field
-          label="Target name"
+          label={<>Target name<Public /></>}
           required
           error={show('target_name')}
           hint="The person or organisation, not the list."
@@ -127,7 +146,7 @@ export default function IntakeModal({ open, onClose, onCreated }) {
             placeholder="e.g. Ava Lindqvist"
           />
         </Field>
-        <Field label="Organisation" hint="Where they do this, if relevant." htmlFor="target_org">
+        <Field label={<>Organisation<Public /></>} hint="Where they do this, if relevant." htmlFor="target_org">
           <TextInput
             id="target_org"
             value={form.target_org}
@@ -169,7 +188,7 @@ export default function IntakeModal({ open, onClose, onCreated }) {
       />
 
       <Field
-        label="Proposed title"
+        label={<>Proposed title<Public /></>}
         required
         error={show('proposed_title')}
         hint="The list's name, as they'll see it."
@@ -183,7 +202,7 @@ export default function IntakeModal({ open, onClose, onCreated }) {
         />
       </Field>
 
-      <Field label="Proposed description" hint="Optional. Sits under the title." htmlFor="proposed_description">
+      <Field label={<>Proposed description<Public /></>} hint="Optional. Sits under the title." htmlFor="proposed_description">
         <TextArea
           id="proposed_description"
           rows={2}
@@ -216,7 +235,7 @@ export default function IntakeModal({ open, onClose, onCreated }) {
             </p>
           )}
         </Field>
-        <Field label="Category" hint="Free text. Copied onto their list." htmlFor="category">
+        <Field label={<>Category<Public /></>} hint="Free text. Copied onto their list." htmlFor="category">
           <TextInput
             id="category"
             value={form.category}
@@ -228,7 +247,7 @@ export default function IntakeModal({ open, onClose, onCreated }) {
 
       <div className="grid grid-cols-2 gap-x-4">
         <Field
-          label="Source URL"
+          label={<>Source URL<Public /></>}
           hint="The exact page you're rebuilding — not the site's home page."
           htmlFor="source_url"
         >
@@ -240,8 +259,8 @@ export default function IntakeModal({ open, onClose, onCreated }) {
           />
         </Field>
         <Field
-          label="Source attribution"
-          hint="Credit line on their list. Points traffic back to them — part of the pitch."
+          label={<>Source attribution<Public /></>}
+          hint="Credit line as it will read: “Compiled from …”. Write it as the source would — a name, not shorthand."
           htmlFor="source_attribution"
         >
           <TextInput

--- a/src/pages/concierge/IntakeModal.test.jsx
+++ b/src/pages/concierge/IntakeModal.test.jsx
@@ -122,3 +122,31 @@ describe('assignee picker', () => {
     expect(document.querySelector('input#assigned_to')).toBeNull();
   });
 });
+
+describe('intake — which fields the target can read', () => {
+  it('marks every field that reaches the public preview', () => {
+    // The preview link is public and forwardable, so these are not internal
+    // notes-to-self. A source attribution typed as shorthand went out to a
+    // target reading "Compiled from ew."
+    renderWithProviders(<IntakeModal open onClose={() => {}} />);
+    const marks = screen.getAllByText(/target sees this/i);
+    expect(marks).toHaveLength(7);
+
+    for (const label of [
+      /Target name/, /Organisation/, /Proposed title/, /Proposed description/,
+      /Category/, /Source URL/, /Source attribution/,
+    ]) {
+      expect(screen.getByText(label).textContent).toMatch(/target sees this/i);
+    }
+  });
+
+  it('leaves the internal-only fields unmarked', () => {
+    // Contact, owner and notes stay out of the preview payload; marking them
+    // would make the marker meaningless.
+    renderWithProviders(<IntakeModal open onClose={() => {}} />);
+    for (const label of [/^Contact/, /^Assigned to/, /^Notes/]) {
+      const el = screen.queryByText(label);
+      if (el) expect(el.textContent).not.toMatch(/target sees this/i);
+    }
+  });
+});


### PR DESCRIPTION
From the first preview render against a real list. The page looked right — clean titles, posters, no `raw_text` leakage — with one thing a real target would see:

> Compiled from **ew**.

Not a bug. `source_attribution` is operator-typed and the placeholder shows the intended form ("Nordic Film Institute, staff picks"). But nothing in the form says that field is *rendered to the target*, and "ew" is a perfectly natural shorthand to type while entering a pitch. On a pitch to Entertainment Weekly's editor, that credit line is an embarrassment.

## What changes

The preview link is public, unauthenticated and forwardable. Seven intake fields reach it — `target_name`, `target_org`, proposed title, proposed description, `category`, `source_url`, `source_attribution` — and each now carries a **target sees this** marker.

Contact, assigned-to and notes stay out of the payload and stay unmarked, so the marker keeps meaning something.

The attribution hint now quotes the sentence it lands in: *Reads "Compiled from …" on the preview. A name, not shorthand.*

The edit modal already grouped these under "The list they'll receive", but its note said they're copied into the account **on claim** — which understates it. They're public from the moment tokens are issued, before anyone has claimed anything.

## Verified, not assumed

The field list comes from the live preview payload for a real pitch, not from the schema. That check also confirmed the invariants: no contact details, no tokens, no `assigned_to`, no notes, no pitch status, nothing resembling `verified_method`.

Documented in the playbook, including that each item's `raw_text` is in the payload — the page renders resolved titles, but the pasted line sits behind it, box-office columns and reference marks included.

`npm test` (219), lint, typecheck, build pass.