### PR TITLE
Say the invite won't work before the target finds out

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -191,6 +191,19 @@ correct match already sitting in their candidate lists. When a resolve goes wron
 `search_year` beside `raw_text`; if those two are identical the cleaner did nothing, which is the first
 thing to check.
 
+## Issuing tokens on a draft
+
+Minting the token pair and the invite *working* are different questions. A preview on a draft is worth
+having — reviewing the list before pitching is exactly when you want one — so `canIssueTokens` still
+allows it. But a draft cannot be claimed: `GET /pitches/invite/:token` answers
+`410 {"valid":false,"reason":"not_claimable_from_draft"}`, and the public signup page has no wording for
+that reason, so the target sees only *"That invite link isn't usable."* — its fallback copy.
+
+`inviteClaimBlockedReason()` mirrors the server so the panel says it first, on our screen instead of
+theirs. **Move the pitch to Pitched before sending the invite.** Only states verified against prod are
+named; an unrecognised status returns `null`, which means "nothing known against it", not "confirmed
+fine".
+
 ## What the preview link exposes
 
 `GET /pitches/preview/:token` is public and unauthenticated, and the link is forwardable, so its payload

--- a/src/pages/concierge/TokensPanel.jsx
+++ b/src/pages/concierge/TokensPanel.jsx
@@ -2,7 +2,14 @@ import { useState } from 'react';
 import { Button } from '../../components/Form';
 import { usePitchMutations } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
-import { canIssueTokens, inviteUrl, isExpired, previewUrl, tokenIssueBlockedReason } from './pitchRules';
+import {
+  canIssueTokens,
+  inviteClaimBlockedReason,
+  inviteUrl,
+  isExpired,
+  previewUrl,
+  tokenIssueBlockedReason,
+} from './pitchRules';
 
 function CopyRow({ label, url, hint }) {
   const [copied, setCopied] = useState(false);
@@ -50,6 +57,9 @@ export default function TokensPanel({ pitch }) {
   const [issued, setIssued] = useState(null);
 
   const blocked = tokenIssueBlockedReason(pitch);
+  // Minting the pair and the invite working are different questions, and the
+  // panel used to answer only the first.
+  const claimBlocked = inviteClaimBlockedReason(pitch);
   const invite = issued?.invite_token || pitch.invite_token;
   const preview = issued?.preview_token || pitch.preview_token;
   const expiresAt = issued?.invite_expires_at || pitch.invite_expires_at;
@@ -112,10 +122,19 @@ export default function TokensPanel({ pitch }) {
 
         <div className="space-y-2">
           <CopyRow label="Preview" url={previewUrl(preview)} hint="Read-only page for the target. Public, no auth." />
+          {claimBlocked && invite && (
+            <div className="rounded border border-red-200 bg-red-50 p-2 text-xs text-red-800">
+              <span className="font-medium">Don&rsquo;t send the invite yet.</span> {claimBlocked}
+            </div>
+          )}
           <CopyRow
             label="Invite"
             url={inviteUrl(invite)}
-            hint="Anyone holding this can claim the draft — send it to the target only."
+            hint={
+              claimBlocked
+                ? 'Would be refused right now — see above.'
+                : 'Anyone holding this can claim the draft — send it to the target only.'
+            }
           />
           {!preview && !invite && (
             <div className="rounded border border-dashed border-gray-200 p-4 text-center text-xs text-gray-400">

--- a/src/pages/concierge/pitchRules.test.js
+++ b/src/pages/concierge/pitchRules.test.js
@@ -18,6 +18,7 @@ import {
   previewUrl,
   tokenIssueBlockedReason,
   typeMatchesPitch,
+  inviteClaimBlockedReason,
 } from './pitchRules';
 
 const pitch = (over = {}) => ({ status: 'draft', can_repitch: false, ...over });
@@ -207,5 +208,42 @@ describe('typeMatchesPitch (the claim-time landmine)', () => {
     // An unresolved row has no type to contradict; don't invent a problem.
     expect(typeMatchesPitch(null, 'Movie')).toBe(true);
     expect(typeMatchesPitch('Movie', undefined)).toBe(true);
+  });
+});
+
+describe('inviteClaimBlockedReason — what the server would say', () => {
+  const pitch = (over = {}) => ({ pitch_id: 'p1', status: 'pitched', invite_used_at: null, ...over });
+
+  it('refuses a draft, because the server does', () => {
+    // Verified against prod: GET /pitches/invite/:token on a draft returns
+    // 410 {"valid":false,"reason":"not_claimable_from_draft"}, and the signup
+    // page has no wording for it — the target sees only "isn't usable".
+    const why = inviteClaimBlockedReason(pitch({ status: 'draft' }));
+    expect(why).toMatch(/draft/i);
+    expect(why).toMatch(/Move it to Pitched/i);
+    // The preview is the reason issuing on a draft stays allowed.
+    expect(why).toMatch(/preview link works/i);
+  });
+
+  it('says nothing against a pitch that has been pitched', () => {
+    expect(inviteClaimBlockedReason(pitch())).toBeNull();
+    expect(inviteClaimBlockedReason(pitch({ status: 'accepted' }))).toBeNull();
+  });
+
+  it('refuses a claimed, declined or archived pitch', () => {
+    expect(inviteClaimBlockedReason(pitch({ invite_used_at: '2026-08-26T00:00:00Z' }))).toMatch(/already been claimed/i);
+    expect(inviteClaimBlockedReason(pitch({ status: 'declined' }))).toMatch(/no longer active/i);
+    expect(inviteClaimBlockedReason(pitch({ status: 'archived' }))).toMatch(/revoked/i);
+  });
+
+  it('does not claim a status is fine merely because it is unrecognised', () => {
+    // null means "nothing known against it" — the caller must not read it as
+    // a guarantee for a status we have never exercised.
+    expect(inviteClaimBlockedReason(pitch({ status: 'no_response' }))).toBeNull();
+    expect(inviteClaimBlockedReason(null)).toBeNull();
+  });
+
+  it('still lets a draft mint tokens, so the preview can be reviewed', () => {
+    expect(canIssueTokens(pitch({ status: 'draft' }))).toBe(true);
   });
 });

--- a/src/pages/concierge/pitchRules.ts
+++ b/src/pages/concierge/pitchRules.ts
@@ -170,6 +170,31 @@ export function tokenIssueBlockedReason(pitch: MaybePitch): string | null {
   return null;
 }
 
+/**
+ * Why the *invite* would be refused if the target clicked it now.
+ *
+ * Distinct from tokenIssueBlockedReason, which governs minting the pair. A
+ * preview is worth having on a draft — reviewing the list before pitching is
+ * exactly when you want one — but the same panel handed out an invite that the
+ * server answers with 410 not_claimable_from_draft, and the failure landed on
+ * the target's screen with copy the public site has no wording for.
+ *
+ * Only states verified against prod are named. A status this doesn't recognise
+ * returns null, which means "nothing known against it", not "confirmed fine".
+ */
+export function inviteClaimBlockedReason(pitch: MaybePitch): string | null {
+  if (!pitch) return null;
+  if (pitch.invite_used_at) return 'This invite has already been claimed — it cannot be used again.';
+  if (pitch.status === 'draft') {
+    return 'This pitch is still a draft, and a draft cannot be claimed — the server refuses the invite with '
+      + 'not_claimable_from_draft, which the signup page can only report as “that invite link isn\u2019t usable”. '
+      + 'Move it to Pitched before sending. The preview link works either way.';
+  }
+  if (pitch.status === 'declined') return 'Target declined — the invite is no longer active.';
+  if (pitch.status === 'archived') return 'Pitch is archived — takedown revoked both tokens.';
+  return null;
+}
+
 export function canIssueTokens(pitch: MaybePitch): boolean {
   return tokenIssueBlockedReason(pitch) === null;
 }


### PR DESCRIPTION
Found on the first end-to-end invite test. The link opened to:

> That invite link isn't usable. You can still create an account below.

## What was actually wrong

Nothing with the link. `?invite=` is the right parameter, the token was fresh and unused. The API refuses it:

```
GET /pitches/invite/cc53fbb9…  →  410 {"valid":false,"reason":"not_claimable_from_draft"}
```

The pitch was still a **draft**. Tokens had been issued, items built, preview verified — but it was never moved to Pitched, and a draft can't be claimed.

The public signup page knows four reasons (`expired`, `already_claimed`, `not_claimable_from_declined`, `not_found`) and this isn't one, so the target gets the fallback copy. The information existed at every layer and reached nobody who could act on it.

## The fix

`tokenIssueBlockedReason` governs *minting* the pair, and it's right to still allow a draft — a preview before pitching is exactly when you want one, and that's how we reviewed this list. What was missing is the second question: would the invite work if clicked?

`inviteClaimBlockedReason()` answers it, mirroring the server. The invite row now leads with **"Don't send the invite yet"**, the reason, and the fix — move it to Pitched. Its hint previously read "Anyone holding this can claim the draft", which was flatly false in this state.

Only statuses verified against prod are named. An unrecognised one returns `null`, meaning "nothing known against it" — never "confirmed fine". `no_response` is deliberately unasserted; we haven't exercised it.

`npm test` (224), lint, typecheck, build pass. Playbook updated.