### PR TITLE
Show where a pitch is and what to do next

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -191,6 +191,27 @@ correct match already sitting in their candidate lists. When a resolve goes wron
 `search_year` beside `raw_text`; if those two are identical the cleaner did nothing, which is the first
 thing to check.
 
+## The guide rail
+
+`pitchFlow.ts` resolves the pitch into an ordered list of steps — details, build, links, mark pitched,
+send, they claim, confirm identity — each `done` / `current` / `blocked` / `waiting` / `todo`, derived
+from server state only. `PitchFlowRail` renders it above the tabs and leaves them alone: it helps someone
+who doesn't know the sequence without slowing down someone who does.
+
+Three rules hold it together, and each exists because of a specific failure:
+
+- **Exactly one step is live.** A rail that answers "what now" with two answers is not a rail. Pinned by
+  a test that sweeps the realistic states.
+- **`done` needs server evidence.** The build step reads `item_count`/`resolved_count`, so a builder full
+  of unsaved rows does not tick it. Nothing records that an invite was *sent*, so that step ticks on the
+  claim rather than pretending to know.
+- **`waiting` needs evidence the ball is with them.** `pitched` only means we marked it pitched; calling
+  that "waiting on them" would excuse an outreach nobody made. `accepted` is the target answering, so the
+  wait is real.
+
+Adding a step means adding it to `pitchFlow` and its test — not to a component. The resolver is pure for
+the same reason `pitchRules` is: the sequence gets pinned by tests instead of by clicking through prod.
+
 ## Issuing tokens on a draft
 
 Minting the token pair and the invite *working* are different questions. A preview on a draft is worth

--- a/src/pages/concierge/PitchDetailPage.jsx
+++ b/src/pages/concierge/PitchDetailPage.jsx
@@ -17,6 +17,7 @@ import {
 import { mockPitchDetail } from './mockPitches';
 import PitchBuilder from './PitchBuilder';
 import TokensPanel from './TokensPanel';
+import PitchFlowRail from './PitchFlowRail';
 import ConfirmIdentityModal from './ConfirmIdentityModal';
 import TakedownModal from './TakedownModal';
 import EditDetailsModal from './EditDetailsModal';
@@ -178,6 +179,15 @@ export default function PitchDetailPage() {
           )}
         </div>
       </div>
+
+      <PitchFlowRail
+        pitch={pitch}
+        confirmed={confirmed}
+        busy={setStatus.isPending}
+        onTab={setTab}
+        onStatus={move}
+        onModal={m => (m === 'identity' ? setIdentityOpen(true) : setEditOpen(true))}
+      />
 
       {/* Tabs */}
       <div className="mb-4 flex gap-1 border-b border-gray-200">

--- a/src/pages/concierge/PitchDetailPage.test.jsx
+++ b/src/pages/concierge/PitchDetailPage.test.jsx
@@ -211,3 +211,44 @@ describe('pitch detail — an expired invite is a lapsed TTL', () => {
     expect(screen.queryByText(/30-day invite has lapsed/i)).toBeNull();
   });
 });
+
+describe('pitch detail — the guide rail', () => {
+  it('names the next move and performs it, on the pitch that shipped a dead invite', async () => {
+    // Draft, list saved, tokens minted: the exact state in which an invite was
+    // sent and the target's screen reported the refusal.
+    serve({
+      ...BASE,
+      status: 'draft',
+      item_count: 40,
+      resolved_count: 40,
+      preview_token: 'ptok',
+      invite_token: 'itok',
+    });
+    client.post.mockResolvedValue({ data: { success: true } });
+    renderDetail();
+
+    await vi.waitFor(() => expect(screen.getByText(/Next: Mark as pitched/i)).toBeTruthy());
+    expect(screen.getByText(/draft cannot be claimed/i)).toBeTruthy();
+
+    fireEvent.click(screen.getAllByRole('button', { name: /^Mark as pitched$/i })[0]);
+    await vi.waitFor(() => expect(client.post).toHaveBeenCalled());
+    expect(client.post.mock.calls[0][0]).toBe('/pitches/p_1/status');
+    expect(client.post.mock.calls[0][1]).toMatchObject({ status: 'pitched' });
+  });
+
+  it('sends you to the builder when the list is the thing that is missing', async () => {
+    serve({ ...BASE, status: 'draft', item_count: 0, resolved_count: 0 });
+    renderDetail();
+
+    await vi.waitFor(() => expect(screen.getByText(/Next: Build the list/i)).toBeTruthy());
+    expect(screen.getByText(/Nothing saved yet/i)).toBeTruthy();
+  });
+
+  it('offers no next move on a pitch that has ended', async () => {
+    serve({ ...BASE, status: 'archived' });
+    renderDetail();
+
+    await vi.waitFor(() => expect(screen.getAllByText(/taken down/i).length).toBeGreaterThan(0));
+    expect(screen.queryByText(/^Next:/i)).toBeNull();
+  });
+});

--- a/src/pages/concierge/PitchFlowRail.jsx
+++ b/src/pages/concierge/PitchFlowRail.jsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import { Button } from '../../components/Form';
+import { currentStep, pitchFlow } from './pitchFlow';
+import { inviteUrl, previewUrl } from './pitchRules';
+
+const MARK = {
+  done: { glyph: '✓', cls: 'text-green-600' },
+  current: { glyph: '●', cls: 'text-indigo-600' },
+  blocked: { glyph: '!', cls: 'text-red-600' },
+  waiting: { glyph: '◷', cls: 'text-blue-500' },
+  todo: { glyph: '○', cls: 'text-gray-300' },
+  skipped: { glyph: '–', cls: 'text-gray-300' },
+};
+
+function Crumb({ step, live }) {
+  const mark = MARK[step.state] || MARK.todo;
+  return (
+    <span
+      className={`inline-flex items-center gap-1 whitespace-nowrap ${
+        live ? 'font-medium text-gray-900' : step.state === 'done' ? 'text-gray-500' : 'text-gray-400'
+      }`}
+      title={step.detail || undefined}
+    >
+      <span className={mark.cls} aria-hidden="true">{mark.glyph}</span>
+      {step.label}
+    </span>
+  );
+}
+
+/**
+ * Where this pitch is, and the one thing to do next.
+ *
+ * A guide rail rather than a wizard: it sits above the tabs and leaves them
+ * alone, so it helps someone who doesn't know the sequence without slowing
+ * down someone who does.
+ */
+export default function PitchFlowRail({ pitch, confirmed, onTab, onStatus, onModal, busy }) {
+  const [copied, setCopied] = useState(false);
+  const steps = pitchFlow({
+    pitch,
+    confirmed,
+    previewHref: previewUrl(pitch?.preview_token),
+    inviteHref: inviteUrl(pitch?.invite_token),
+  });
+  const live = currentStep(steps);
+  if (steps.length === 0) return null;
+
+  async function run(action) {
+    if (!action) return;
+    if (action.kind === 'tab') onTab?.(action.tab);
+    else if (action.kind === 'status') onStatus?.(action.to);
+    else if (action.kind === 'modal') onModal?.(action.modal);
+    else if (action.kind === 'link') window.open(action.href, '_blank', 'noopener');
+    else if (action.kind === 'copy') {
+      try {
+        await navigator.clipboard.writeText(action.text);
+        setCopied(true);
+        setTimeout(() => setCopied(false), 1500);
+      } catch {
+        setCopied(false);
+      }
+    }
+  }
+
+  const ended = steps.length === 1 && steps[0].state === 'skipped';
+
+  return (
+    <div className="mb-4 rounded-lg border border-gray-200 bg-white">
+      <div className="flex flex-wrap items-center gap-x-4 gap-y-1 border-b border-gray-100 px-4 py-2 text-xs">
+        {steps.map(s => (
+          <Crumb key={s.id} step={s} live={live?.id === s.id} />
+        ))}
+      </div>
+
+      {live && (
+        <div className="flex flex-wrap items-center gap-3 px-4 py-3">
+          <div className="min-w-0 flex-1">
+            <div className="text-xs font-medium text-gray-900">
+              {ended ? live.label : live.state === 'waiting' ? `Waiting: ${live.label}` : `Next: ${live.label}`}
+            </div>
+            {live.detail && <div className="mt-0.5 text-xs text-gray-500">{live.detail}</div>}
+          </div>
+          {live.extra && (
+            <Button size="sm" disabled={busy} onClick={() => run(live.extra)}>
+              {live.extra.label}
+            </Button>
+          )}
+          {live.action && live.state !== 'waiting' && (
+            <Button variant="primary" size="sm" disabled={busy} onClick={() => run(live.action)}>
+              {copied && live.action.kind === 'copy' ? 'Copied' : live.action.label}
+            </Button>
+          )}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/src/pages/concierge/pitchFlow.test.js
+++ b/src/pages/concierge/pitchFlow.test.js
@@ -1,0 +1,160 @@
+import { describe, expect, it } from 'vitest';
+import { currentStep, pitchFlow } from './pitchFlow';
+
+const base = {
+  pitch_id: 'p1',
+  target_name: 'Bob Bob',
+  proposed_title: 'Scary movies',
+  thing_type: 'Movie',
+  status: 'draft',
+  can_repitch: false,
+  item_count: 0,
+  resolved_count: 0,
+  preview_token: null,
+  invite_token: null,
+  invite_used_at: null,
+  invite_expires_at: null,
+};
+
+const flow = (over = {}, extra = {}) =>
+  pitchFlow({ pitch: { ...base, ...over }, previewHref: '/p', inviteHref: '/i', ...extra });
+const live = (over = {}, extra = {}) => currentStep(flow(over, extra));
+const stateOf = (steps, id) => steps.find(s => s.id === id)?.state;
+
+describe('pitchFlow — one live step, always', () => {
+  it('never shows two things to do at once', () => {
+    // The rail answers "what now" with one answer or it isn't a rail.
+    const cases = [
+      {},
+      { item_count: 40, resolved_count: 37 },
+      { item_count: 40, resolved_count: 40 },
+      { item_count: 40, resolved_count: 40, preview_token: 'p', invite_token: 'i' },
+      { status: 'pitched', item_count: 40, resolved_count: 40, preview_token: 'p', invite_token: 'i' },
+      { status: 'accepted', item_count: 40, resolved_count: 40, preview_token: 'p', invite_token: 'i' },
+      { status: 'provisioned', item_count: 40, resolved_count: 40, preview_token: 'p', invite_token: 'i', invite_used_at: '2026-08-26T00:00:00Z' },
+    ];
+    for (const c of cases) {
+      const n = flow(c).filter(s => ['current', 'blocked', 'waiting'].includes(s.state)).length;
+      expect(n, JSON.stringify(c)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  it('returns nothing at all without a pitch', () => {
+    expect(pitchFlow({ pitch: null })).toEqual([]);
+    expect(currentStep([])).toBeNull();
+  });
+});
+
+describe('pitchFlow — the order the work actually happens in', () => {
+  it('starts at the list, not the links', () => {
+    expect(live().label).toMatch(/Build the list/i);
+    expect(live().action).toEqual({ kind: 'tab', tab: 'build', label: 'Open the builder' });
+  });
+
+  it('counts what is saved, not what is on screen', () => {
+    // item_count/resolved_count are the server's numbers. A builder full of
+    // unsaved rows must not tick this step.
+    const step = live({ item_count: 40, resolved_count: 37 });
+    expect(step.label).toMatch(/Build the list/i);
+    expect(step.detail).toMatch(/3 of 40/);
+  });
+
+  it('offers the links once the list is whole', () => {
+    expect(live({ item_count: 40, resolved_count: 40 }).label).toMatch(/Generate the links/i);
+  });
+
+  it('offers the preview alongside the links, since that is when you check it', () => {
+    const steps = flow({ item_count: 40, resolved_count: 40, preview_token: 'p', invite_token: 'i' });
+    expect(steps.find(s => s.id === 'links').extra).toEqual({ kind: 'link', href: '/p', label: 'Open preview' });
+  });
+});
+
+describe('pitchFlow — the gate that sent a dead invite', () => {
+  const built = { item_count: 40, resolved_count: 40, preview_token: 'p', invite_token: 'i' };
+
+  it('puts "mark as pitched" before "send the invite"', () => {
+    // The failure this exists for: tokens issued on a draft, invite sent, and
+    // the server answered the *target* with 410 not_claimable_from_draft.
+    const step = live(built);
+    expect(step.label).toMatch(/Mark as pitched/i);
+    expect(step.detail).toMatch(/draft cannot be claimed/i);
+    expect(step.action).toEqual({ kind: 'status', to: 'pitched', label: 'Mark as pitched' });
+  });
+
+  it('holds the invite back while the pitch is a draft', () => {
+    expect(stateOf(flow(built), 'send')).toBe('todo');
+  });
+
+  it('hands over the invite once it has been pitched', () => {
+    const step = live({ ...built, status: 'pitched' });
+    expect(step.label).toMatch(/Send the invite/i);
+    expect(step.action).toEqual({ kind: 'copy', text: '/i', label: 'Copy invite link' });
+  });
+
+  it('does not pretend to know a link was sent', () => {
+    expect(live({ ...built, status: 'pitched' }).detail).toMatch(/nothing records the send/i);
+  });
+});
+
+describe('pitchFlow — steps that are not the operator\'s move', () => {
+  const sent = { item_count: 40, resolved_count: 40, preview_token: 'p', invite_token: 'i', status: 'pitched' };
+
+  it('waits only once there is evidence the ball is with them', () => {
+    // `pitched` means we marked it pitched, not that anyone received anything —
+    // calling that "waiting on them" would excuse an outreach nobody made.
+    expect(stateOf(flow(sent), 'claim')).toBe('todo');
+
+    // `accepted` is the target answering, so the wait is real.
+    const claim = flow({ ...sent, status: 'accepted' }).find(s => s.id === 'claim');
+    expect(claim.state).toBe('waiting');
+    expect(claim.action).toBeNull();
+    expect(claim.detail).toMatch(/accepted and have not claimed/i);
+    // Re-sending is the one useful move while waiting.
+    expect(claim.extra).toEqual({ kind: 'copy', text: '/i', label: 'Copy invite link' });
+  });
+
+  it('sends you to Outreach for an expired invite rather than re-issuing behind your back', () => {
+    // Re-issue kills any link already sent; that consequence is spelled out in
+    // the panel, so the rail navigates instead of acting.
+    const step = live({ ...sent, invite_expires_at: '2020-01-01T00:00:00Z' });
+    expect(step.state).toBe('blocked');
+    expect(step.action.kind).toBe('tab');
+    expect(step.action.label).not.toMatch(/^Re-issue tokens$/);
+  });
+});
+
+describe('pitchFlow — identity comes after the claim, never before', () => {
+  const claimed = {
+    item_count: 40, resolved_count: 40, preview_token: 'p', invite_token: 'i',
+    invite_used_at: '2026-08-26T00:00:00Z', status: 'provisioned',
+  };
+
+  it('asks for identity only once the draft is provisioned', () => {
+    const step = live(claimed);
+    expect(step.label).toMatch(/Confirm identity/i);
+    expect(step.detail).toMatch(/claim alone is not proof/i);
+  });
+
+  it('keeps identity out of reach before the claim', () => {
+    expect(stateOf(flow({ ...claimed, status: 'pitched', invite_used_at: null }), 'identity')).toBe('todo');
+  });
+
+  it('finishes when identity is confirmed', () => {
+    const steps = flow(claimed, { confirmed: { user_id: 'u1' } });
+    expect(stateOf(steps, 'identity')).toBe('done');
+    expect(currentStep(steps)).toBeNull();
+  });
+});
+
+describe('pitchFlow — pitches that have ended', () => {
+  it('offers no next move on an archived pitch', () => {
+    const steps = flow({ status: 'archived' });
+    expect(steps).toHaveLength(1);
+    expect(steps[0].state).toBe('skipped');
+    expect(steps[0].detail).toMatch(/taken down/i);
+  });
+
+  it('says declined is terminal rather than offering a re-pitch', () => {
+    expect(flow({ status: 'declined' })[0].detail).toMatch(/terminal/i);
+  });
+});

--- a/src/pages/concierge/pitchFlow.ts
+++ b/src/pages/concierge/pitchFlow.ts
@@ -1,0 +1,240 @@
+// The concierge job as a sequence, derived from server state alone.
+//
+// The pitch page is organised by object — Build, Outreach, Identity, Audit —
+// while the work is a pipeline with gates. Nothing said which gate you were at,
+// so each one was found by hitting it: tokens were issued on a draft, the
+// invite was sent, and the *target's* screen reported the refusal.
+//
+// Every precondition that failed that way already existed in `pitchRules`. What
+// was missing is direction. Those predicates only ever answered "may I?", which
+// disables a control; read forward they answer "what now?", which is the same
+// knowledge pointed at the operator instead of at a button.
+//
+// Pure and dependency-free, like pitchRules, so the sequence is pinned by tests
+// rather than by clicking through prod.
+
+import {
+  canConfirmIdentity,
+  inviteClaimBlockedReason,
+  isExpired,
+  type MaybePitch,
+  type Pitch,
+} from './pitchRules';
+
+export type StepState =
+  /** Finished — the server shows the evidence, not a local flag. */
+  | 'done'
+  /** The operator's move, right now. */
+  | 'current'
+  /** Reachable, but something must be fixed first — `detail` says what. */
+  | 'blocked'
+  /** Nothing to do; the ball is with the target. */
+  | 'waiting'
+  /** Later. */
+  | 'todo'
+  /** Overtaken — this pitch ended, or the step no longer applies. */
+  | 'skipped';
+
+/**
+ * What the rail's button does. Declarative so the resolver stays pure and the
+ * component owns navigation, mutation and the clipboard.
+ */
+export type FlowAction =
+  | { kind: 'tab'; tab: string; label: string }
+  | { kind: 'status'; to: string; label: string }
+  | { kind: 'link'; href: string; label: string }
+  | { kind: 'copy'; text: string; label: string }
+  | { kind: 'modal'; modal: string; label: string };
+
+export interface FlowStep {
+  id: string;
+  label: string;
+  state: StepState;
+  /** Why it's blocked, what's being waited on, or what remains. */
+  detail?: string | null;
+  /** The step's own action. Present on `current` and `blocked` steps. */
+  action?: FlowAction | null;
+  /** Secondary action, e.g. opening a preview that's already generated. */
+  extra?: FlowAction | null;
+}
+
+export interface FlowInput {
+  pitch: MaybePitch;
+  /** The identity record from the verification surface, if one exists. */
+  confirmed?: { user_id?: string | null } | null;
+  /** Built by the caller from the token — the resolver stays URL-free. */
+  previewHref?: string | null;
+  inviteHref?: string | null;
+  now?: number;
+}
+
+/** Statuses from which no further outreach happens. */
+const ENDED: Record<string, string> = {
+  archived: 'This pitch was taken down — its contact details were purged and both tokens revoked.',
+  declined: 'The target declined. Declined is terminal; archive it rather than re-pitching.',
+};
+
+function step(
+  id: string,
+  label: string,
+  state: StepState,
+  detail?: string | null,
+  action?: FlowAction | null,
+  extra?: FlowAction | null,
+): FlowStep {
+  return { id, label, state, detail: detail ?? null, action: action ?? null, extra: extra ?? null };
+}
+
+/**
+ * The ordered steps, with exactly one of them live.
+ *
+ * "Live" is `current` when it's the operator's move, `blocked` when something
+ * must be fixed first, and `waiting` when the target holds the ball — that last
+ * one matters, because a waiting step with no button used to read as a missing
+ * feature and send people hunting.
+ */
+export function pitchFlow({ pitch, confirmed, previewHref, inviteHref, now = Date.now() }: FlowInput): FlowStep[] {
+  if (!pitch) return [];
+  const p = pitch as Pitch;
+  const ended = ENDED[p.status];
+
+  const items = p.item_count ?? 0;
+  const resolved = p.resolved_count ?? 0;
+  const listReady = items > 0 && resolved === items;
+  const hasTokens = !!p.preview_token && !!p.invite_token;
+  const claimed = !!p.invite_used_at;
+  const identityDone = !!confirmed;
+  const inviteExpired = isExpired(p.invite_expires_at, now);
+
+  // A terminal pitch has no next move, and pretending otherwise invites one.
+  if (ended) {
+    return [
+      step('ended', p.status === 'archived' ? 'Taken down' : 'Declined', 'skipped', ended),
+    ];
+  }
+
+  const steps: FlowStep[] = [];
+
+  // 1. Details. Intake requires these, so this exists to show the sequence has
+  //    a beginning, not because it can realistically fail.
+  steps.push(
+    step('details', 'Target details', p.proposed_title && p.thing_type ? 'done' : 'current',
+      p.proposed_title && p.thing_type ? null : 'The list needs a proposed title and a type.',
+      { kind: 'modal', modal: 'edit', label: 'Edit details…' }),
+  );
+
+  // 2. The list. `item_count`/`resolved_count` are the server's, so this tracks
+  //    what is *saved*, never what happens to be on screen unsaved.
+  const buildDetail = items === 0
+    ? 'Nothing saved yet — paste the source list and resolve it.'
+    : `${items - resolved} of ${items} row(s) still unresolved.`;
+  steps.push(
+    step('build', 'Build the list', listReady ? 'done' : 'current',
+      listReady ? `${items} item(s) saved.` : buildDetail,
+      { kind: 'tab', tab: 'build', label: items === 0 ? 'Open the builder' : 'Finish the list' }),
+  );
+
+  // 3. Links. Both are minted together; the preview is the reason this is
+  //    allowed on a draft at all.
+  steps.push(
+    step('links', 'Generate the links', hasTokens ? 'done' : listReady ? 'current' : 'todo',
+      hasTokens ? 'Preview and invite links exist.' : 'Mints the preview and invite pair.',
+      { kind: 'tab', tab: 'outreach', label: hasTokens ? 'Re-issue…' : 'Generate links' },
+      hasTokens && previewHref ? { kind: 'link', href: previewHref, label: 'Open preview' } : null),
+  );
+
+  // 4. Pitched. The gate that sent a dead invite to a target: an invite is
+  //    refused from draft, and the public signup page has no wording for it.
+  const isDraft = p.status === 'draft';
+  steps.push(
+    step('pitched', 'Mark as pitched', isDraft ? (hasTokens ? 'current' : 'todo') : 'done',
+      isDraft
+        ? 'A draft cannot be claimed — the invite is refused until this moves. Check the preview first.'
+        : 'Ready to send.',
+      { kind: 'status', to: 'pitched', label: 'Mark as pitched' }),
+  );
+
+  // 5. Sending. There is no server evidence of a send, so this ticks when the
+  //    claim lands rather than pretending to know.
+  const claimBlocked = inviteClaimBlockedReason(p);
+  // `accepted` is the target saying yes, which is evidence they received the
+  // invite. Nothing else records a send.
+  const answered = p.status === 'accepted';
+  const sendState: StepState = claimed || answered
+    ? 'done'
+    : !hasTokens || isDraft
+      ? 'todo'
+      : inviteExpired
+        ? 'blocked'
+        : 'current';
+  steps.push(
+    step('send', 'Send the invite', sendState,
+      inviteExpired && !claimed
+        // Deliberately not the Outreach panel's wording. The rail states, the
+        // panel explains; the same sentence twice on one screen is noise.
+        ? 'The invite lapsed after 30 days. Re-issuing replaces both links.'
+        : claimBlocked && !claimed
+          ? claimBlocked
+          : claimed
+            ? 'Claimed.'
+            : 'Send the invite link to the target — nothing records the send, so this ticks when they claim.',
+      inviteExpired
+        // Navigates rather than re-issuing here: re-issue kills any link
+        // already sent, and the Outreach panel is where that is spelled out.
+        ? { kind: 'tab', tab: 'outreach', label: 'Re-issue in Outreach' }
+        : inviteHref
+          ? { kind: 'copy', text: inviteHref, label: 'Copy invite link' }
+          : { kind: 'tab', tab: 'outreach', label: 'Open outreach' }),
+  );
+
+  // 6. Theirs. `waiting` is claimed only where there is evidence the ball is
+  //    with them — they accepted. Before that the operator still owes a send,
+  //    and calling it "waiting" would excuse an outreach nobody made.
+  steps.push(
+    step('claim', 'They claim the draft', claimed ? 'done' : answered ? 'waiting' : 'todo',
+      claimed
+        ? 'Claimed — the list is theirs now.'
+        : answered
+          ? 'They accepted and have not claimed yet. Nothing to do here; the link is with them.'
+          : 'Nothing to do here; the link is with them.',
+      null,
+      // Re-sending is the one useful move while waiting.
+      answered && inviteHref ? { kind: 'copy', text: inviteHref, label: 'Copy invite link' } : null),
+  );
+
+  // 7. Identity, and only after the claim: a claim proves someone held the
+  //    link, never that they are the target.
+  steps.push(
+    step('identity', 'Confirm identity', identityDone ? 'done' : canConfirmIdentity(p) ? 'current' : 'todo',
+      identityDone
+        ? 'Confirmed against evidence.'
+        : canConfirmIdentity(p)
+          ? 'Needs evidence a human checked — the claim alone is not proof of identity.'
+          : 'Available once the target has claimed and the draft is provisioned.',
+      { kind: 'modal', modal: 'identity', label: 'Confirm identity…' }),
+  );
+
+  return firstLiveOnly(steps);
+}
+
+/**
+ * Leave one live step. Later steps whose preconditions happen to be met still
+ * read as `todo`, so the rail always answers "what now" with one thing.
+ */
+function firstLiveOnly(steps: FlowStep[]): FlowStep[] {
+  let seen = false;
+  return steps.map(s => {
+    if (s.state === 'done' || s.state === 'skipped') return s;
+    if (seen) return { ...s, state: 'todo', action: null };
+    if (s.state === 'current' || s.state === 'blocked' || s.state === 'waiting') {
+      seen = true;
+      return s;
+    }
+    return s;
+  });
+}
+
+/** The one step the rail leads with, if any. */
+export function currentStep(steps: FlowStep[]): FlowStep | null {
+  return steps.find(s => s.state === 'current' || s.state === 'blocked' || s.state === 'waiting') || null;
+}


### PR DESCRIPTION
The workflow needs too much training, and this session is the evidence: every wall hit today was a precondition that existed in code and was never surfaced *forward*.

## The diagnosis

The pitch page is organised by **object** — Build, Outreach, Identity, Audit — while the job is a **pipeline with gates**. Nothing shows which gate you're at, so each is discovered by hitting it. The worst case: issue tokens on a draft, send the invite, and the *target's* screen reports `not_claimable_from_draft` in copy the public site has no wording for.

## The pattern

`pitchRules.ts` already says its job is to "make sure the button was never offered". Those predicates only ever answer **"may I?"**, which disables a control. Read forward, the same predicates answer **"what now?"** — the same knowledge pointed at the operator instead of at a button. No new machinery.

`pitchFlow.ts` resolves a pitch into ordered steps, each `done` / `current` / `blocked` / `waiting` / `todo`, from server state only. `PitchFlowRail` renders it above the tabs and leaves them alone — a guide rail, not a wizard, so it helps someone who doesn't know the sequence without slowing down someone who does.

## Three rules, each from a specific failure

- **Exactly one step is live.** A rail that answers "what now" with two answers isn't a rail. Pinned by a test sweeping the realistic states — it caught a phantom where "send" and "they claim" were both live.
- **`done` needs server evidence.** The build step reads `item_count`/`resolved_count`, so a builder full of unsaved rows doesn't tick it. Nothing records that an invite was *sent*, so that step ticks on the claim rather than pretending to know.
- **`waiting` needs evidence the ball is with them.** `pitched` only means we marked it pitched — calling that "waiting on them" would excuse an outreach nobody made. `accepted` is the target answering, so the wait is real, and that's the one place a re-send is offered.

## Deliberately not doing

Re-issuing an expired invite from the rail. That kills any link already sent, and the Outreach panel is where the consequence is spelled out — so the rail navigates there instead. Two identically-labelled buttons on one screen was also a real ambiguity, not just a test failure.

Adding a step means editing `pitchFlow` and its test, never a component.

`npm test` (244), lint, typecheck, build pass. Playbook updated.

Next candidate, not in this PR: a "Next action" column on the outreach board, so a queue of pitches shows what each is waiting on without opening it.