### PR TITLE
Count the item rows, not aggregates the endpoint omits

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -202,8 +202,11 @@ Three rules hold it together, and each exists because of a specific failure:
 
 - **Exactly one step is live.** A rail that answers "what now" with two answers is not a rail. Pinned by
   a test that sweeps the realistic states.
-- **`done` needs server evidence.** The build step reads `item_count`/`resolved_count`, so a builder full
-  of unsaved rows does not tick it. Nothing records that an invite was *sent*, so that step ticks on the
+- **`done` needs server evidence.** The build step counts the item rows `GET /pitches/:id` returns, so a
+  builder full of unsaved rows does not tick it. It counts the *rows*, not `item_count`/`resolved_count`:
+  that endpoint returns the array without the aggregates, and reading the aggregates there reported
+  "nothing saved yet" for a finished forty-item list — and showed 0/0 in the page header. `itemCounts()`
+  prefers the array and falls back to the aggregates for a board row, which has the counts and no array. Nothing records that an invite was *sent*, so that step ticks on the
   claim rather than pretending to know.
 - **`waiting` needs evidence the ball is with them.** `pitched` only means we marked it pitched; calling
   that "waiting on them" would excuse an outreach nobody made. `accepted` is the target answering, so the

--- a/src/pages/concierge/PitchDetailPage.jsx
+++ b/src/pages/concierge/PitchDetailPage.jsx
@@ -18,6 +18,7 @@ import { mockPitchDetail } from './mockPitches';
 import PitchBuilder from './PitchBuilder';
 import TokensPanel from './TokensPanel';
 import PitchFlowRail from './PitchFlowRail';
+import { itemCounts } from './pitchFlow';
 import ConfirmIdentityModal from './ConfirmIdentityModal';
 import TakedownModal from './TakedownModal';
 import EditDetailsModal from './EditDetailsModal';
@@ -83,6 +84,9 @@ export default function PitchDetailPage() {
 
   const { pitch, items, events } = data;
   const transitions = offeredTransitions(pitch);
+  // This endpoint returns the rows but not the aggregates, so the header read
+  // 0/0 on a finished list.
+  const counts = itemCounts(pitch, items);
 
   async function move(next) {
     setNote(null);
@@ -123,7 +127,7 @@ export default function PitchDetailPage() {
             <span className="rounded bg-gray-100 px-2 py-0.5 text-xs text-gray-600">{pitch.thing_type}</span>
           )}
           <span className="text-xs tabular-nums text-gray-500">
-            {pitch.resolved_count ?? 0}/{pitch.item_count ?? 0} resolved
+            {counts.resolved}/{counts.items} resolved
           </span>
           {pitch.status === 'declined' && (
             <span className="text-xs text-gray-500">Declined is terminal — archive only, never re-pitch.</span>
@@ -182,6 +186,7 @@ export default function PitchDetailPage() {
 
       <PitchFlowRail
         pitch={pitch}
+        items={items}
         confirmed={confirmed}
         busy={setStatus.isPending}
         onTab={setTab}

--- a/src/pages/concierge/PitchDetailPage.test.jsx
+++ b/src/pages/concierge/PitchDetailPage.test.jsx
@@ -216,14 +216,13 @@ describe('pitch detail — the guide rail', () => {
   it('names the next move and performs it, on the pitch that shipped a dead invite', async () => {
     // Draft, list saved, tokens minted: the exact state in which an invite was
     // sent and the target's screen reported the refusal.
-    serve({
-      ...BASE,
-      status: 'draft',
-      item_count: 40,
-      resolved_count: 40,
-      preview_token: 'ptok',
-      invite_token: 'itok',
-    });
+    serve(
+      { ...BASE, status: 'draft', preview_token: 'ptok', invite_token: 'itok' },
+      // The rows themselves, because the detail endpoint returns those and not
+      // the aggregates — serving a count with an empty array was a state the
+      // server never produces.
+      Array.from({ length: 40 }, (_, i) => ({ position: i, thing_id: `movie_${i}`, raw_text: `row ${i}` })),
+    );
     client.post.mockResolvedValue({ data: { success: true } });
     renderDetail();
 

--- a/src/pages/concierge/PitchFlowRail.jsx
+++ b/src/pages/concierge/PitchFlowRail.jsx
@@ -34,10 +34,11 @@ function Crumb({ step, live }) {
  * alone, so it helps someone who doesn't know the sequence without slowing
  * down someone who does.
  */
-export default function PitchFlowRail({ pitch, confirmed, onTab, onStatus, onModal, busy }) {
+export default function PitchFlowRail({ pitch, items, confirmed, onTab, onStatus, onModal, busy }) {
   const [copied, setCopied] = useState(false);
   const steps = pitchFlow({
     pitch,
+    items,
     confirmed,
     previewHref: previewUrl(pitch?.preview_token),
     inviteHref: inviteUrl(pitch?.invite_token),

--- a/src/pages/concierge/pitchFlow.test.js
+++ b/src/pages/concierge/pitchFlow.test.js
@@ -1,5 +1,5 @@
 import { describe, expect, it } from 'vitest';
-import { currentStep, pitchFlow } from './pitchFlow';
+import { currentStep, itemCounts, pitchFlow } from './pitchFlow';
 
 const base = {
   pitch_id: 'p1',
@@ -156,5 +156,40 @@ describe('pitchFlow — pitches that have ended', () => {
 
   it('says declined is terminal rather than offering a re-pitch', () => {
     expect(flow({ status: 'declined' })[0].detail).toMatch(/terminal/i);
+  });
+});
+
+describe('itemCounts — the rows are the truth when we have them', () => {
+  const rows = [
+    { position: 0, thing_id: 'movie_it_2017' },
+    { position: 1, thing_id: 'movie_jaws_1975' },
+    { position: 2, thing_id: null },
+  ];
+
+  it('counts the rows the detail endpoint returned, not the aggregates it omits', () => {
+    // GET /pitches/:id returns items but no item_count/resolved_count, so the
+    // rail reported "nothing saved yet" about a finished forty-item list.
+    expect(itemCounts({ ...base }, rows)).toEqual({ items: 3, resolved: 2 });
+  });
+
+  it('accepts either signal for a resolved row', () => {
+    expect(itemCounts({ ...base }, [{ resolved: true }, { thing_id: 'x' }, {}])).toEqual({ items: 3, resolved: 2 });
+  });
+
+  it('falls back to the aggregates for a board row, which has no array', () => {
+    expect(itemCounts({ ...base, item_count: 40, resolved_count: 37 })).toEqual({ items: 40, resolved: 37 });
+  });
+
+  it('reads an empty array as an empty list, not as missing data', () => {
+    expect(itemCounts({ ...base, item_count: 40, resolved_count: 40 }, [])).toEqual({ items: 0, resolved: 0 });
+  });
+
+  it('drives the rail past the build step on the pitch that was stuck', () => {
+    const steps = pitchFlow({
+      pitch: { ...base, status: 'draft', preview_token: 'p', invite_token: 'i' },
+      items: Array.from({ length: 40 }, (_, i) => ({ position: i, thing_id: `movie_${i}` })),
+    });
+    expect(steps.find(s => s.id === 'build').state).toBe('done');
+    expect(currentStep(steps).label).toMatch(/Mark as pitched/i);
   });
 });

--- a/src/pages/concierge/pitchFlow.ts
+++ b/src/pages/concierge/pitchFlow.ts
@@ -60,6 +60,15 @@ export interface FlowStep {
 
 export interface FlowInput {
   pitch: MaybePitch;
+  /**
+   * The item rows from GET /pitches/:id, when the caller has them.
+   *
+   * Preferred over the pitch's own counts, which that endpoint does not
+   * aggregate — reading them there reported "nothing saved yet" for a pitch
+   * holding forty saved items. A board row has the counts and no array; this
+   * page has the array. Both are server truth.
+   */
+  items?: unknown;
   /** The identity record from the verification surface, if one exists. */
   confirmed?: { user_id?: string | null } | null;
   /** Built by the caller from the token — the resolver stays URL-free. */
@@ -86,6 +95,26 @@ function step(
 }
 
 /**
+ * How many items a pitch holds, and how many resolved.
+ *
+ * The array wins when there is one: GET /pitches/:id returns the rows but not
+ * the aggregates, so trusting the aggregates there said "nothing saved yet"
+ * about a finished forty-item list.
+ */
+export function itemCounts(pitch: MaybePitch, itemRows?: unknown): { items: number; resolved: number } {
+  if (Array.isArray(itemRows)) {
+    const rows = itemRows.filter((r): r is Record<string, unknown> => typeof r === 'object' && r !== null);
+    return {
+      items: rows.length,
+      // An item is resolved when it points at a thing. Some surfaces also say
+      // so outright; either is enough.
+      resolved: rows.filter(r => !!r.thing_id || r.resolved === true).length,
+    };
+  }
+  return { items: pitch?.item_count ?? 0, resolved: pitch?.resolved_count ?? 0 };
+}
+
+/**
  * The ordered steps, with exactly one of them live.
  *
  * "Live" is `current` when it's the operator's move, `blocked` when something
@@ -93,13 +122,14 @@ function step(
  * one matters, because a waiting step with no button used to read as a missing
  * feature and send people hunting.
  */
-export function pitchFlow({ pitch, confirmed, previewHref, inviteHref, now = Date.now() }: FlowInput): FlowStep[] {
+export function pitchFlow(
+  { pitch, items: itemRows, confirmed, previewHref, inviteHref, now = Date.now() }: FlowInput,
+): FlowStep[] {
   if (!pitch) return [];
   const p = pitch as Pitch;
   const ended = ENDED[p.status];
 
-  const items = p.item_count ?? 0;
-  const resolved = p.resolved_count ?? 0;
+  const { items, resolved } = itemCounts(p, itemRows);
   const listReady = items > 0 && resolved === items;
   const hasTokens = !!p.preview_token && !!p.invite_token;
   const claimed = !!p.invite_used_at;


### PR DESCRIPTION
Reported on the pitch we've been building: the rail says **"Next: Build the list — Nothing saved yet"** on a pitch holding 40 saved items.

## Cause

The rail read `pitch.item_count` / `pitch.resolved_count`. `GET /pitches/:id` returns the item **rows** and doesn't aggregate them, so both are `undefined` → `0`.

The page header has had the same bug all along, showing **0/0 resolved**. Nobody noticed because the Build tab shows the real rows a click away.

## Fix

`itemCounts(pitch, items)` prefers the array when the caller has one, and falls back to the aggregates for a board row, which has the counts and no array. Both are server truth; only one is present at a time. Header and rail now share it.

An item counts as resolved when it points at a thing (`thing_id`), or says so outright (`resolved: true`) — the preview endpoint uses the latter shape.

## Why the test didn't catch it

The rail's own test served `item_count: 40` alongside an empty `items` array — a combination the server never produces. It passed while the page was wrong. It now serves 40 rows, and a new case pins that an empty array means an empty list rather than missing data.

`npm test` (249), lint, typecheck, build pass. Playbook updated.