### PR TITLE
Offer the preview beside the invite, and say to send it first

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -215,6 +215,24 @@ Three rules hold it together, and each exists because of a specific failure:
 Adding a step means adding it to `pitchFlow` and its test — not to a component. The resolver is pure for
 the same reason `pitchRules` is: the sequence gets pinned by tests instead of by clicking through prod.
 
+## Which link to send, and in what order
+
+**Preview first, then the invite.** They are not alternatives:
+
+| | Preview | Invite |
+|---|---|---|
+| Auth | none | signup completes the claim |
+| Shows | all items | the list's *title* only |
+| Forwardable | yes, by design | it is a capability — send to the target only |
+
+The invite page reads *"A list is waiting for you — create your account and **&lt;title&gt;** lands in it as
+a private draft."* It never shows the contents, so an invite sent on its own asks someone to create an
+account for a list they have not seen. The preview page deliberately does not offer a claim button
+either; it says to use the link in the message, because a forwardable token must not escalate into a
+capability.
+
+The rail's send step therefore offers both, preview first.
+
 ## Issuing tokens on a draft
 
 Minting the token pair and the invite *working* are different questions. A preview on a draft is worth

--- a/src/pages/concierge/PitchDetailPage.test.jsx
+++ b/src/pages/concierge/PitchDetailPage.test.jsx
@@ -251,3 +251,24 @@ describe('pitch detail — the guide rail', () => {
     expect(screen.queryByText(/^Next:/i)).toBeNull();
   });
 });
+
+describe('pitch detail — sending both links', () => {
+  const pitched = { ...BASE, status: 'pitched', preview_token: 'ptok', invite_token: 'itok' };
+  const rows = Array.from({ length: 40 }, (_, i) => ({ position: i, thing_id: `movie_${i}` }));
+
+  it('confirms the button that was actually pressed', async () => {
+    // Two copy buttons sharing one flag confirmed the wrong one.
+    const writeText = vi.fn().mockResolvedValue(undefined);
+    Object.assign(navigator, { clipboard: { writeText } });
+    serve(pitched, rows);
+    renderDetail();
+
+    await vi.waitFor(() => expect(screen.getByText(/Next: Send the invite/i)).toBeTruthy());
+    fireEvent.click(screen.getByRole('button', { name: /^Copy preview link$/i }));
+
+    await vi.waitFor(() => expect(screen.getByRole('button', { name: /^Copied$/i })).toBeTruthy());
+    expect(writeText).toHaveBeenCalledWith(expect.stringContaining('/pitch/ptok'));
+    // The invite button is untouched and still says what it does.
+    expect(screen.getByRole('button', { name: /^Copy invite link$/i })).toBeTruthy();
+  });
+});

--- a/src/pages/concierge/PitchFlowRail.jsx
+++ b/src/pages/concierge/PitchFlowRail.jsx
@@ -35,7 +35,9 @@ function Crumb({ step, live }) {
  * down someone who does.
  */
 export default function PitchFlowRail({ pitch, items, confirmed, onTab, onStatus, onModal, busy }) {
-  const [copied, setCopied] = useState(false);
+  // Which button was copied, not merely that one was: the send step offers
+  // two, and a shared flag confirms the wrong one.
+  const [copied, setCopied] = useState(null);
   const steps = pitchFlow({
     pitch,
     items,
@@ -55,10 +57,10 @@ export default function PitchFlowRail({ pitch, items, confirmed, onTab, onStatus
     else if (action.kind === 'copy') {
       try {
         await navigator.clipboard.writeText(action.text);
-        setCopied(true);
-        setTimeout(() => setCopied(false), 1500);
+        setCopied(action.label);
+        setTimeout(() => setCopied(c => (c === action.label ? null : c)), 1500);
       } catch {
-        setCopied(false);
+        setCopied(null);
       }
     }
   }
@@ -83,12 +85,12 @@ export default function PitchFlowRail({ pitch, items, confirmed, onTab, onStatus
           </div>
           {live.extra && (
             <Button size="sm" disabled={busy} onClick={() => run(live.extra)}>
-              {live.extra.label}
+              {copied === live.extra.label ? 'Copied' : live.extra.label}
             </Button>
           )}
           {live.action && live.state !== 'waiting' && (
             <Button variant="primary" size="sm" disabled={busy} onClick={() => run(live.action)}>
-              {copied && live.action.kind === 'copy' ? 'Copied' : live.action.label}
+              {copied === live.action.label ? 'Copied' : live.action.label}
             </Button>
           )}
         </div>

--- a/src/pages/concierge/pitchFlow.test.js
+++ b/src/pages/concierge/pitchFlow.test.js
@@ -92,7 +92,15 @@ describe('pitchFlow — the gate that sent a dead invite', () => {
   });
 
   it('does not pretend to know a link was sent', () => {
-    expect(live({ ...built, status: 'pitched' }).detail).toMatch(/nothing records the send/i);
+    expect(live({ ...built, status: 'pitched' }).detail).toMatch(/nothing records a send/i);
+  });
+
+  it('offers the preview beside the invite, and says to send it first', () => {
+    // The invite page names the list and shows none of it, so an invite sent
+    // alone asks someone to create an account for a list they've never seen.
+    const step = live({ ...built, status: 'pitched' });
+    expect(step.extra).toEqual({ kind: 'copy', text: '/p', label: 'Copy preview link' });
+    expect(step.detail).toMatch(/preview first/i);
   });
 });
 

--- a/src/pages/concierge/pitchFlow.ts
+++ b/src/pages/concierge/pitchFlow.ts
@@ -207,14 +207,20 @@ export function pitchFlow(
           ? claimBlocked
           : claimed
             ? 'Claimed.'
-            : 'Send the invite link to the target — nothing records the send, so this ticks when they claim.',
+            // Both links, in that order. The invite page names the list and
+            // shows none of it, so an invite sent alone asks someone to create
+            // an account for a list they have never seen.
+            : 'Send the preview first, then the invite — the invite page names the list but shows none of it. '
+              + 'Nothing records a send, so this ticks when they claim.',
       inviteExpired
         // Navigates rather than re-issuing here: re-issue kills any link
         // already sent, and the Outreach panel is where that is spelled out.
         ? { kind: 'tab', tab: 'outreach', label: 'Re-issue in Outreach' }
         : inviteHref
           ? { kind: 'copy', text: inviteHref, label: 'Copy invite link' }
-          : { kind: 'tab', tab: 'outreach', label: 'Open outreach' }),
+          : { kind: 'tab', tab: 'outreach', label: 'Open outreach' },
+      // Offered beside it, because it is the half that should go first.
+      !inviteExpired && previewHref ? { kind: 'copy', text: previewHref, label: 'Copy preview link' } : null),
   );
 
   // 6. Theirs. `waiting` is claimed only where there is evidence the ball is


### PR DESCRIPTION
Asked mid-flow: *should the invitee have to sign up before seeing the list?* No — and the rail was pushing them toward exactly that.

## The two links are not alternatives

| | Preview | Invite |
|---|---|---|
| Auth | none | signup completes the claim |
| Shows | all 40 items | the list's **title** only |
| Forwardable | yes, by design | it's a capability — target only |

The invite page reads *"A list is waiting for you — create your account and **Scary movies** lands in it as a private draft."* It names the list and shows none of it. An invite sent on its own asks someone to create an account for a list they've never seen.

The preview page correspondingly refuses to offer a claim button — it says "use the link in the message that sent you this preview", so a forwarded preview token can't escalate into a capability. That's right, and it means the operator must send both.

## What changes

The rail's send step offered *Copy invite link* and nothing else. It now offers **Copy preview link** beside it and says which goes first.

Also fixes the confirmation: with two copy buttons, a shared `copied` boolean flashed "Copied" on whichever button was primary rather than the one pressed.

`npm test` (251), lint, typecheck, build pass. Playbook gains a "which link to send, and in what order" section.

## Open question for the backend, not filed yet

The invite page could show the list rather than just its name. `GET /pitches/invite/:token` returns `list_title` and `expires_at`; it could return enough to render a preview, or simply return the `preview_token`. An invite holder can already claim the list outright, so handing them the strictly weaker preview token leaks nothing — but it's their call whether that's the shape they want.