### PR TITLE
Send a display line the target can be shown

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -215,6 +215,22 @@ Three rules hold it together, and each exists because of a specific failure:
 Adding a step means adding it to `pitchFlow` and its test — not to a component. The resolver is pure for
 the same reason `pitchRules` is: the sequence gets pinned by tests instead of by clicking through prod.
 
+## display_text — the line a target may be shown
+
+`PUT /pitches/:id/items` carries `display_text` per item alongside `raw_text` (listgem-platform#565,
+#567). `raw_text` is operator notation and stays that way — it is the provenance record and the builder
+shows it. `display_text` is the title we actually searched on, i.e. `queryFor(row).title`, or `null` when
+there is nothing to show.
+
+It matters because an unresolved row reaches the target. After a claim, skipped items appear as chips in
+the leftovers flow — the same component a user meets after their own import — so a pasted table row would
+otherwise read to them as `22 Resident Evil: The Final Chapter 2017 $314,101,190 [43][44]`.
+
+The server deliberately has **no fallback to `raw_text` and no heuristic stripping**: guessing at someone
+else's formatting fails silently, and a title mangled into something plausible is worse than notation
+that is visibly notation. Which is why the write side is ours — we hold the cleaned title already, and
+reverse-engineering it server-side would be a guess.
+
 ## Which link to send, and in what order
 
 **Preview first, then the invite.** They are not alternatives:

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -718,3 +718,34 @@ describe('builder — discarding a build', () => {
     expect(screen.queryByRole('button', { name: /discard build/i })).toBeNull();
   });
 });
+
+describe('builder — the display line reaches the request', () => {
+  beforeEach(() => {
+    client.get.mockReset();
+    client.put.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+    client.put.mockResolvedValue({ data: { success: true, item_count: 2 } });
+  });
+
+  it('puts display_text on the wire, not merely in the payload builder', async () => {
+    // A value that never arrives is the failure shape this guards: the pure
+    // function can be right while nothing reaches the request.
+    sessionStorage.setItem('pitchDraft:p_dt', JSON.stringify({
+      v: 1,
+      savedAt: Date.now(),
+      rows: [
+        { raw_text: '22 Resident Evil: The Final Chapter 2017 $314,101,190 [43][44]', thing_id: null, status: 'unresolved', candidates: [], match: null, note: '', dropped: false, confidence: null, reason: null, query: { title: 'Resident Evil: The Final Chapter', year: 2017, header: false } },
+        { raw_text: 'Persona (1966) 🇸🇪 8.6/10', thing_id: 'movie_persona_1966', status: 'resolved', candidates: [], match: { title: 'Persona', type: 'Movie', year: 1966 }, note: '', dropped: false, confidence: 1, reason: null },
+      ],
+    }));
+    renderWithProviders(<PitchBuilder pitchId="p_dt" thingType="Movie" items={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /save items/i }));
+
+    await vi.waitFor(() => expect(client.put).toHaveBeenCalled());
+    const sent = client.put.mock.calls[0][1].items;
+    expect(sent.map(i => i.display_text)).toEqual(['Resident Evil: The Final Chapter', 'Persona']);
+    // The unresolved row is the one that can reach the target as a chip.
+    expect(sent[0].resolution_status).toBe('ambiguous');
+    expect(sent[0].raw_text).toMatch(/\$314,101,190/);
+  });
+});

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -748,3 +748,51 @@ describe('matchConcern — a missing year is not a disagreement', () => {
     expect(matchConcern(withMatchYear(1991))).toMatch(/2001.*1991/);
   });
 });
+
+describe('display_text — what the target may be shown', () => {
+  it('sends the title we searched on, not the operator notation', () => {
+    // The line that exposed this in production, from the invite teaser:
+    // "The Emigrants + The New Land (1971, 1972) 🇸🇪 8.6/10"
+    const rows = rowsFromParsed(normalizeParsed([
+      'The Emigrants + The New Land (1971, 1972) 🇸🇪 8.6/10',
+      'Persona (1966) 🇸🇪 8.6/10',
+    ]));
+    expect(toItemsPayload(rows).map(i => i.display_text)).toEqual([
+      'The Emigrants + The New Land',
+      'Persona',
+    ]);
+    // raw_text is untouched — it stays our provenance record.
+    expect(toItemsPayload(rows)[0].raw_text).toBe('The Emigrants + The New Land (1971, 1972) 🇸🇪 8.6/10');
+  });
+
+  it('strips a pasted table row down to its title', () => {
+    const rows = rowsFromParsed(normalizeParsed([
+      'Rank Film Year Worldwide gross Ref',
+      '22 Resident Evil: The Final Chapter 2017 $314,101,190 [43][44]',
+      '23 Annabelle: Creation 2017 $306,592,201 [45][46]',
+      '24 Resident Evil: Afterlife 2010 $300,228,084 [47][48]',
+    ]));
+    // The heading row arrives dropped, so it never reaches the payload.
+    expect(toItemsPayload(rows).map(i => i.display_text)).toEqual([
+      'Resident Evil: The Final Chapter',
+      'Annabelle: Creation',
+      'Resident Evil: Afterlife',
+    ]);
+  });
+
+  it('sends null rather than an empty string when there is nothing to show', () => {
+    // The server has no fallback by design; null means "no display line".
+    const rows = rowsFromParsed(normalizeParsed(['   🇸🇪  8.6/10 ']));
+    expect(toItemsPayload(rows)[0].display_text).toBeNull();
+  });
+
+  it('labels resolved rows too, so a row does not depend on staying resolved', () => {
+    const rows = rowsFromParsed(normalizeParsed(['Persona (1966)']));
+    rows[0].thing_id = 'movie_persona_1966';
+    expect(toItemsPayload(rows)[0]).toMatchObject({
+      thing_id: 'movie_persona_1966',
+      resolution_status: 'resolved',
+      display_text: 'Persona',
+    });
+  });
+});

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -119,6 +119,21 @@ export interface ItemPayload {
   thing_id: string | null;
   resolution_status: 'resolved' | 'ambiguous';
   note: string | null;
+  /**
+   * A line safe to show the target (listgem-platform#565).
+   *
+   * `raw_text` is operator notation — a pasted table row still carrying its
+   * rank, box office and reference marks, or a curator's
+   * "… (1971, 1972) 🇸🇪 8.6/10". A row that never resolved reaches the target
+   * anyway, as a chip in the leftovers flow after they claim, and that surface
+   * has no business showing our working notes.
+   *
+   * This is the title we actually searched on, so it is derived, never guessed:
+   * the server deliberately does not fall back to `raw_text` or strip it by
+   * regex, because mangling someone's formatting fails silently and a
+   * plausible-but-wrong title is worse than one that is visibly notation.
+   */
+  display_text: string | null;
 }
 
 export interface RowCounts {
@@ -547,6 +562,10 @@ export function toItemsPayload(rows: BuilderRow[]): ItemPayload[] {
       thing_id: row.thing_id || null,
       resolution_status: row.thing_id ? 'resolved' : 'ambiguous',
       note: row.note?.trim() ? row.note.trim() : null,
+      // Null rather than an empty string when there is nothing to show: the
+      // server treats null as "no display line", and an unlabelled chip beats
+      // a blank one.
+      display_text: queryFor(row).title.trim() || null,
     }));
 }
 


### PR DESCRIPTION
The write half of listgem-platform#565. Their #567 is merged and deployed; #568 carries the reporting half. This fills the column.

## Why the builder owns this

An unresolved row reaches the target. After a claim, skipped items render as chips in the leftovers flow — the same component a user meets after their own import — so today they'd read:

```
22 Resident Evil: The Final Chapter 2017 $314,101,190 [43][44]
The Emigrants + The New Land (1971, 1972) 🇸🇪 8.6/10
```

Operator notation, on the one surface facing the person being pitched.

The server deliberately has **no fallback to `raw_text` and no heuristic stripping**, and that's the right call: guessing at someone else's formatting fails silently, and a title mangled into something plausible is worse than notation that's visibly notation. We already hold the cleaned title — it's what we searched on — so reverse-engineering it server-side would be a guess where we have a fact.

## What changes

`PUT /pitches/:id/items` now carries `display_text` per item: `queryFor(row).title`, or `null` when there's nothing to show. `raw_text` is untouched — it stays the provenance record, and the builder still shows it.

Sent for resolved rows too. It costs nothing, and it means a row's label doesn't depend on it staying resolved.

## Asserted on the wire

One test checks `toItemsPayload`; another checks what `client.put` actually received. A correct payload builder whose value never reaches the request is precisely the shape that bit their `provisionPitch` SELECT this week, and `tmdb_id` before that — code that looks right, tests that pass, value never arrives.

`npm test` (256), lint, typecheck, build pass. Playbook updated.