### PR TITLE
Show cover art on candidate rows

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -231,6 +231,21 @@ else's formatting fails silently, and a title mangled into something plausible i
 that is visibly notation. Which is why the write side is ours — we hold the cleaned title already, and
 reverse-engineering it server-side would be a guess.
 
+## Cover art
+
+Candidate rows carry a thumbnail, because the adjudication they support is often visual: `It (1990)` and
+`It (2017)` differ by a year in text and instantly by poster. The mis-picks that prompted this — Hannibal
+resolving to The Silence of the Lambs, The Final Chapter to the 2002 original — were all chosen from a
+list of title, year and type.
+
+`imageUrl()` mirrors the web app's `getImageUrl`: Yelp serves 403 to a hotlinked image, so those go
+through the API's `/images/proxy`, and everything else is used directly rather than putting a CDN's
+traffic on our egress. `/images` is in the dev proxy list, or it 404s in dev while working in a build.
+
+The thumbnail box is rendered whether or not there is an image. Hiding a failed load is the wrong default
+when a whole source can fail at once: a hotlink-blocked list would degrade into something that looks
+deliberately text-only, and nobody reports what they cannot see.
+
 ## Two item counts that are both right
 
 The admin and the invite page count different things, and neither is wrong:

--- a/src/api/imageUrl.js
+++ b/src/api/imageUrl.js
@@ -1,0 +1,20 @@
+/**
+ * Cover art, routed through the API's proxy where the source hotlink-blocks.
+ *
+ * Mirrors the web app's `getImageUrl` (listgem-website `src/lib/image-proxy.ts`).
+ * Yelp serves 403 to a hotlinked image, so a Place list — a chef's city guide
+ * is an ordinary pitch, not a hypothetical — would show a row of nothing.
+ *
+ * Kept as a list rather than a proxy-everything rule: proxying TMDB posters
+ * through our own API would put a CDN's traffic on our egress for no reason.
+ */
+const HOTLINK_BLOCKED = ['yelpcdn.com'];
+
+const API_URL = import.meta.env.DEV ? '' : import.meta.env.VITE_API_URL || 'http://localhost:3000';
+
+export function imageUrl(url) {
+  if (!url || typeof url !== 'string') return null;
+  return HOTLINK_BLOCKED.some(host => url.includes(host))
+    ? `${API_URL}/images/proxy?url=${encodeURIComponent(url)}`
+    : url;
+}

--- a/src/api/imageUrl.test.js
+++ b/src/api/imageUrl.test.js
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest';
+import { imageUrl } from './imageUrl';
+
+describe('imageUrl', () => {
+  it('proxies a source that blocks hotlinks', () => {
+    // Yelp answers 403 to a hotlinked image, so a Place pitch — a chef's city
+    // guide is an ordinary one — would otherwise show a row of nothing.
+    const url = imageUrl('https://s3-media0.fl.yelpcdn.com/bphoto/abc/o.jpg');
+    expect(url).toContain('/images/proxy?url=');
+    expect(url).toContain(encodeURIComponent('https://s3-media0.fl.yelpcdn.com/bphoto/abc/o.jpg'));
+  });
+
+  it('leaves everything else alone', () => {
+    // Proxying TMDB through our own API would put a CDN's traffic on our
+    // egress for no reason.
+    const tmdb = 'https://image.tmdb.org/t/p/w200/poster.jpg';
+    expect(imageUrl(tmdb)).toBe(tmdb);
+  });
+
+  it('returns null for nothing to show', () => {
+    expect(imageUrl(null)).toBeNull();
+    expect(imageUrl('')).toBeNull();
+    expect(imageUrl(undefined)).toBeNull();
+    expect(imageUrl(42)).toBeNull();
+  });
+});

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -11,6 +11,7 @@ import {
   useSearchToAdd,
 } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
+import { imageUrl } from '../../api/imageUrl';
 import { typeMatchesPitch } from './pitchRules';
 import { diagnosticsText } from './diagnostics';
 import { clearDraft, readDraft, saveDraft } from './draftStore';
@@ -62,6 +63,32 @@ function Kbd({ children }) {
   );
 }
 
+/**
+ * Cover art for a candidate.
+ *
+ * The box is always there, filled or not. Hiding a failed image is the wrong
+ * default when a whole source can fail at once: a hotlink-blocking host would
+ * degrade to a row that looks deliberately text-only, and nobody reports what
+ * they cannot see.
+ */
+function Thumb({ candidate }) {
+  const src = imageUrl(candidate.image_url);
+  const [broken, setBroken] = useState(false);
+  return (
+    <span className="h-9 w-6 shrink-0 overflow-hidden rounded-sm bg-gray-100">
+      {src && !broken && (
+        <img
+          src={src}
+          alt=""
+          loading="lazy"
+          onError={() => setBroken(true)}
+          className="h-full w-full object-cover"
+        />
+      )}
+    </span>
+  );
+}
+
 function CandidateRow({ candidate, chosen, onPick, busy, wrongType }) {
   // A federated hit with no thing_id isn't in our registry yet. Picking it now
   // materialises it through the same kernel path a user add uses
@@ -79,7 +106,7 @@ function CandidateRow({ candidate, chosen, onPick, busy, wrongType }) {
             ? `Not in the registry yet — adds it from ${candidate.source || 'the source'}, then attaches`
             : undefined
       }
-      className={`flex w-full items-baseline gap-2 rounded border px-2 py-1 text-left text-xs disabled:opacity-50 ${
+      className={`flex w-full items-center gap-2 rounded border px-2 py-1 text-left text-xs disabled:opacity-50 ${
         wrongType
           ? 'cursor-not-allowed border-gray-200 text-gray-400 line-through decoration-gray-300'
           : needsCreate
@@ -89,6 +116,7 @@ function CandidateRow({ candidate, chosen, onPick, busy, wrongType }) {
             : 'border-gray-200 hover:bg-gray-50'
       }`}
     >
+      <Thumb candidate={candidate} />
       <span className="min-w-0 flex-1 truncate text-gray-800">{candidate.title}</span>
       {candidate.creator && <span className="truncate text-gray-500">{candidate.creator}</span>}
       {candidate.type && <span className="text-gray-400">{candidate.type}</span>}

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -749,3 +749,46 @@ describe('builder — the display line reaches the request', () => {
     expect(sent[0].raw_text).toMatch(/\$314,101,190/);
   });
 });
+
+describe('builder — cover art on the candidates', () => {
+  const ambiguous = [{
+    raw_text: '16 Hannibal 2001 $351,692,268 [31][32]',
+    thing_id: null, status: 'ambiguous', note: '', dropped: false, confidence: null,
+    reason: 'no_confident_match', match: null,
+    candidates: [
+      { thing_id: 'movie_hannibal_2001', title: 'Hannibal', type: 'Movie', year: 2001, image_url: 'https://image.tmdb.org/t/p/w200/h.jpg', in_registry: true, source: 'local', creator: null, score: 0.7, source_type: null, source_id: null },
+      { thing_id: 'place_x', title: "Hannibal's Kitchen", type: 'Place', year: null, image_url: 'https://s3-media0.fl.yelpcdn.com/bphoto/x/o.jpg', in_registry: true, source: 'local', creator: null, score: 0.4, source_type: null, source_id: null },
+      { thing_id: 'movie_no_art', title: 'Hannibal Rising', type: 'Movie', year: 2007, image_url: null, in_registry: true, source: 'local', creator: null, score: 0.3, source_type: null, source_id: null },
+    ],
+  }];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+    sessionStorage.setItem('pitchDraft:p_art', JSON.stringify({ v: 1, savedAt: Date.now(), rows: ambiguous }));
+  });
+
+  it('shows the art, so two films with one title are told apart on sight', () => {
+    // The mis-pick this exists for: Hannibal (2001) resolved to The Silence of
+    // the Lambs, chosen from a candidate list of title, year and type alone.
+    renderWithProviders(<PitchBuilder pitchId="p_art" thingType="Movie" items={[]} />);
+    const art = screen.getAllByRole('presentation', { hidden: true });
+    expect(art.length).toBeGreaterThan(0);
+    expect(art[0].getAttribute('src')).toBe('https://image.tmdb.org/t/p/w200/h.jpg');
+  });
+
+  it('routes a hotlink-blocking source through the proxy', () => {
+    renderWithProviders(<PitchBuilder pitchId="p_art" thingType="Movie" items={[]} />);
+    const srcs = screen.getAllByRole('presentation', { hidden: true }).map(i => i.getAttribute('src'));
+    expect(srcs.some(s => s?.includes('/images/proxy?url='))).toBe(true);
+  });
+
+  it('keeps the box when there is no art, so the rows stay aligned', () => {
+    // A candidate with no image must not shift its title out of line with the
+    // others — and a whole source failing must look like empty boxes, not like
+    // a list that was always text.
+    renderWithProviders(<PitchBuilder pitchId="p_art" thingType="Movie" items={[]} />);
+    expect(screen.getByText('Hannibal Rising')).toBeTruthy();
+    expect(screen.getAllByRole('presentation', { hidden: true })).toHaveLength(2);
+  });
+});

--- a/vite.config.js
+++ b/vite.config.js
@@ -15,6 +15,8 @@ export default defineConfig({
         // here, they 404 against the dev server while working fine in a
         // production build, which points debugging at entirely the wrong place.
         '/search-to-add', '/types', '/things',
+        // Cover art from hotlink-blocking sources is fetched through the API.
+        '/images',
       ].map(
         (path) => [
           path,


### PR DESCRIPTION
Came out of the frontend team's review of listgem-website#107. Checking whether their `getImageUrl` finding applied here turned up something more interesting: **the concierge surfaces render no images at all.**

Which is the mirror of the argument we spent today making. Covers sell a list where titles don't — and the builder asks an operator to choose among seven candidates using title, year and type alone.

Every mis-pick this week came off that list:

| Row | Picked | Should have been |
|---|---|---|
| Hannibal (2001) | The Silence of the Lambs (1991) | Hannibal (2001) |
| Resident Evil: The Final Chapter (2017) | Resident Evil (2002) | The Final Chapter (2016) |

Both are one-glance discriminations with a poster, and careful reading without one.

## What changes

A thumbnail on each candidate row, and `imageUrl()` mirroring the web app's `getImageUrl`: Yelp answers 403 to a hotlinked image, so those go through the API's `/images/proxy`; everything else is used directly rather than putting a CDN's traffic on our egress. `/images` added to the dev proxy list, or it 404s in dev while working fine in a build.

## The box stays when the image doesn't

Deliberate, and it's the lesson from their review. My `onError` on the invite strip *hid* failed loads, which is fine for one slow cover and wrong as a default when a whole source can fail at once — a hotlink-blocked list degrades into something that looks deliberately text-only, and nobody reports what they can't see. Here the box is always rendered: a broken source looks like empty boxes, which is a bug report.

It also keeps the rows aligned when one candidate has no art.

## Tests

Three on the builder — TMDB art rendered, a Yelp URL routed through the proxy, and a candidate with no image keeping its box — plus three on the helper. Fixture is the real Hannibal candidate list.

`npm test` (262), lint, typecheck, build pass. Playbook updated.