### PR TITLE
Read the poster from where prod keeps it

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -238,6 +238,12 @@ Candidate rows carry a thumbnail, because the adjudication they support is often
 resolving to The Silence of the Lambs, The Final Chapter to the 2002 original — were all chosen from a
 list of title, year and type.
 
+Art is read from `image_url`, then `metadata.poster_url`, then `metadata.image`. The name matters more
+than it looks: on prod every Movie thing has a **null** top-level `image_url` and a populated
+`metadata.poster_url` — 11,952 of 11,952 — so reading only the obvious field renders an empty box for
+every candidate, and a hand-written fixture would have passed either way. The test uses a response copied
+off the wire for that reason.
+
 `imageUrl()` mirrors the web app's `getImageUrl`: Yelp serves 403 to a hotlinked image, so those go
 through the API's `/images/proxy`, and everything else is used directly rather than putting a CDN's
 traffic on our egress. `/images` is in the dev proxy list, or it 404s in dev while working in a build.

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -6,6 +6,7 @@ import {
   chunkForBatch,
   normalizeParseOutcome,
   normalizeParsed,
+  normalizeCandidate,
   normalizeResolution,
   normalizeSearchResults,
   pendingIndices,
@@ -794,5 +795,47 @@ describe('display_text — what the target may be shown', () => {
       resolution_status: 'resolved',
       display_text: 'Persona',
     });
+  });
+});
+
+describe('candidate art — where production actually keeps it', () => {
+  // Verbatim from GET /things/movie_it_2017_687266e4 on prod, trimmed. Written
+  // from the wire rather than by hand: the whole failure is that a hand-written
+  // fixture carries whichever field name its author picked, and passes.
+  const PROD_THING = {
+    thing_id: 'movie_it_2017_687266e4',
+    type: 'Movie',
+    canonical_ids: { imdb_id: 'tt1396484', tmdb_movie_id: '346364' },
+    image_url: null,
+    metadata: {
+      year: '2017',
+      title: 'It',
+      rating: 7.241,
+      source: 'tmdb_api',
+      poster_url: 'https://image.tmdb.org/t/p/w500/9E2y5Q7WlCVNEhP5GiVTjhEhx1o.jpg',
+      backdrop_url: 'https://image.tmdb.org/t/p/w500/qVGpxnjrGlHaSTCqTQI6viBDSfp.jpg',
+    },
+  };
+
+  it('finds the poster where prod keeps it, not where the field is named', () => {
+    // Every Movie thing: image_url null, metadata.poster_url populated.
+    expect(normalizeCandidate(PROD_THING).image_url)
+      .toBe('https://image.tmdb.org/t/p/w500/9E2y5Q7WlCVNEhP5GiVTjhEhx1o.jpg');
+  });
+
+  it('prefers a top-level image_url when the endpoint supplies one', () => {
+    // The preview endpoint transforms items and does set it.
+    const transformed = { ...PROD_THING, image_url: 'https://cdn/transformed.jpg' };
+    expect(normalizeCandidate(transformed).image_url).toBe('https://cdn/transformed.jpg');
+  });
+
+  it('takes metadata.image as the last of the chain', () => {
+    expect(normalizeCandidate({ thing_id: 't', title: 'X', metadata: { image: 'https://cdn/i.jpg' } }).image_url)
+      .toBe('https://cdn/i.jpg');
+  });
+
+  it('reports null rather than guessing when there is no art', () => {
+    expect(normalizeCandidate({ thing_id: 't', title: 'X', metadata: { backdrop_url: 'https://cdn/b.jpg' } }).image_url)
+      .toBeNull();
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -205,7 +205,18 @@ export function normalizeCandidate(raw: unknown): Candidate | null {
     // `subtitle` is where /search-to-add puts artist/author/director.
     creator: firstString(src.creator, src.author, src.artist, src.subtitle),
     year: typeof year === 'number' || typeof year === 'string' ? year : null,
-    image_url: firstString(src.image_url, src.image),
+    // Art hides under several names, and the one this used to read is the one
+    // production leaves empty: every Movie thing has metadata.poster_url and a
+    // null top-level image_url (checked against prod, 2026-08-26 — 11,952 of
+    // 11,952). A fixture would have been written with whichever name its author
+    // picked and the tests would have passed either way.
+    image_url: firstString(
+      src.image_url,
+      isObject(src.metadata) ? src.metadata.poster_url : null,
+      isObject(src.metadata) ? src.metadata.image : null,
+      src.poster_url,
+      src.image,
+    ),
     score: typeof src.score === 'number' ? src.score : null,
     // /resolve returns graph neighbours, which are in the registry by
     // definition; only /search-to-add says so explicitly.


### PR DESCRIPTION
The candidate thumbnails merged in #63 an hour ago render an **empty box for every candidate**. Caught only because the backend team hit the identical trap one repo over and wrote it up.

## What's wrong

`normalizeCandidate` read `image_url`. Checked against prod:

```
GET /things/movie_it_2017_687266e4
  image_url            → null
  metadata.poster_url  → https://image.tmdb.org/t/p/w500/9E2y5Q7WlCVNEhP5GiVTjhEhx1o.jpg
```

Their numbers: `Movie things: 11,952 | image_url: 0 | poster_url: 11,952`. So the field I read is empty on every Movie in the registry.

The chain is now `image_url` → `metadata.poster_url` → `metadata.image`, which is what the web app does in five separate places — evidence the shape varies by endpoint, and evidence I could have found before shipping.

## The part worth keeping

The test fixture is a response **copied off the wire**, not written by hand. That's the whole lesson, and it's theirs: a hand-written fixture carries whichever field name its author happens to pick, so it passes whether or not the code works.

Mine did. #63 shipped with a green suite, three tests asserting thumbnails render, and every one of them fed `image_url` to a function that reads `image_url` — measuring my fixture's agreement with itself. That was an hour after I wrote a comment on their PR about this exact failure shape.

Fifth instance this week: `||` dropping `tmdb_id`, send-test reporting phantom sends, `provisionPitch` not selecting `display_text`, their invite sample, and now this. All five pass their tests, because all five have the right *shape* — it's the value that never arrives.

`npm test` (266), lint, typecheck, build pass. Playbook records where the art lives and why the fixture came off the wire.