### PR TITLE
Read the identity badge from the server

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -231,6 +231,22 @@ else's formatting fails silently, and a title mangled into something plausible i
 that is visibly notation. Which is why the write side is ours — we hold the cleaned title already, and
 reverse-engineering it server-side would be a guess.
 
+## Where the identity badge comes from
+
+The pitch page reads it from `GET /verification/:userId/history` for `pitch.provisioned_user_id`, whose
+`verified` field is the current state. Never from what the session happens to remember: held in
+component state it looked right until the first refresh, when the grant was real and the page had no
+idea.
+
+Two things it deliberately does not do. There is **no mock fallback** — `VerificationTool` has one, which
+is fine for a browsing surface and wrong here, because inventing a confirmation is worse than showing
+none when the subject is whether a badge was granted. And the query is keyed on **live** data only: this
+page falls back to a sample pitch when the API has nothing, and asking about a fabricated user id would
+answer a real question with invented data.
+
+`confirmIdentity` invalidates `['verification']` as well as `['pitches']`, since the grant lands on the
+user rather than the pitch.
+
 ## Cover art
 
 Candidate rows carry a thumbnail, because the adjudication they support is often visual: `It (1990)` and

--- a/src/api/hooks.js
+++ b/src/api/hooks.js
@@ -430,7 +430,13 @@ export function usePitchMutations(defaultPitchId) {
     confirmIdentity: useMutation({
       mutationFn: ({ pitchId, ...body }) =>
         client.post(`/pitches/${pitchId || defaultPitchId}/confirm-identity`, body).then(r => r.data),
-      onSuccess: invalidate,
+      // The grant lands on the *user*, not the pitch, so the verification
+      // queries have to be dropped too — the pitch page reads the badge from
+      // there, and invalidating only pitches left a stale "not confirmed".
+      onSuccess: () => {
+        invalidate();
+        qc.invalidateQueries({ queryKey: ['verification'] });
+      },
     }),
   };
 }

--- a/src/pages/concierge/PitchDetailPage.jsx
+++ b/src/pages/concierge/PitchDetailPage.jsx
@@ -3,7 +3,7 @@ import { Link, useParams } from 'react-router-dom';
 import PageHeader from '../../components/PageHeader';
 import { Button } from '../../components/Form';
 import VerifiedBadge from '../../components/VerifiedBadge';
-import { usePitch, usePitchMutations } from '../../api/hooks';
+import { usePitch, usePitchMutations, useVerificationHistory } from '../../api/hooks';
 import { apiErrorMessage } from '../../api/errors';
 import {
   STATUS_LABEL,
@@ -61,7 +61,18 @@ export default function PitchDetailPage() {
   const [identityOpen, setIdentityOpen] = useState(false);
   const [takedownOpen, setTakedownOpen] = useState(false);
   const [editOpen, setEditOpen] = useState(false);
-  const [confirmed, setConfirmed] = useState(null);
+  // Read from the server, never from what this session happens to remember.
+  // Held locally, the badge vanished on refresh: the grant was real, the page
+  // just had no idea. Deliberately no mock fallback — inventing a confirmation
+  // is worse than showing none, and this one grants a badge.
+  // Live data only. `data` below falls back to a sample pitch, and asking the
+  // verification API about an invented user id would be a fabricated answer to
+  // a question about whether someone is verified.
+  const provisionedUserId = query.data?.pitch?.provisioned_user_id || null;
+  const verification = useVerificationHistory(provisionedUserId);
+  const confirmed = verification.data?.verified?.type
+    ? { user_id: provisionedUserId, verified: verification.data.verified }
+    : null;
 
   const live = query.data?.pitch ? query.data : null;
   const sample = mockPitchDetail(pitchId);
@@ -308,8 +319,9 @@ export default function PitchDetailPage() {
         open={identityOpen}
         pitch={pitch}
         onClose={() => setIdentityOpen(false)}
-        onConfirmed={data => {
-          setConfirmed(data);
+        onConfirmed={() => {
+          // The badge itself comes from the refetch the mutation triggers, not
+          // from this callback — so what shows here survives a reload.
           setNote({ ok: true, text: 'Identity confirmed — badge granted.' });
         }}
       />

--- a/src/pages/concierge/PitchDetailPage.test.jsx
+++ b/src/pages/concierge/PitchDetailPage.test.jsx
@@ -272,3 +272,54 @@ describe('pitch detail — sending both links', () => {
     expect(screen.getByRole('button', { name: /^Copy invite link$/i })).toBeTruthy();
   });
 });
+
+describe('pitch detail — a confirmed identity survives a reload', () => {
+  const provisioned = {
+    ...BASE,
+    status: 'provisioned',
+    invite_used_at: '2026-08-26T19:00:00Z',
+    provisioned_user_id: 'usr_7',
+    provisioned_list_id: 'lst_9',
+  };
+
+  function serveWith(pitch, verification) {
+    client.get.mockImplementation(url => {
+      if (url === '/pitches/p_1') return Promise.resolve({ data: { pitch, items: [], events: [] } });
+      if (url === '/verification/usr_7/history') return Promise.resolve({ data: verification });
+      return Promise.reject(new Error('not mocked'));
+    });
+  }
+
+  it('reads the badge from the server, not from what this session did', async () => {
+    // Held in component state, the confirmation vanished on refresh: the grant
+    // was real and the page had no idea.
+    serveWith(provisioned, { verified: { type: 'individual', proof: null, since: '2026-08-26T19:05:00Z' }, history: [] });
+    renderDetail();
+
+    fireEvent.click(await screen.findByRole('button', { name: /identity/i }));
+    await vi.waitFor(() => expect(screen.getByText(/Identity confirmed for usr_7/i)).toBeTruthy());
+  });
+
+  it('says nothing when the account is not verified', async () => {
+    serveWith(provisioned, { verified: null, history: [] });
+    renderDetail();
+
+    fireEvent.click(await screen.findByRole('button', { name: /identity/i }));
+    await vi.waitFor(() => expect(screen.getByRole('button', { name: /confirm identity/i })).toBeTruthy());
+    expect(screen.queryByText(/Identity confirmed for/i)).toBeNull();
+  });
+
+  it('never asks about a user id the sample pitch invented', async () => {
+    // The page falls back to a mock pitch when the API has nothing; querying
+    // verification for that fabricated id would answer a real question with
+    // invented data.
+    // Reset first: the mock's call history accumulates across tests in this
+    // file, and the claim here is about what *this* render asks for.
+    client.get.mockReset();
+    client.get.mockRejectedValue(new Error('offline'));
+    renderDetail();
+
+    await vi.waitFor(() => expect(client.get).toHaveBeenCalled());
+    expect(client.get.mock.calls.every(c => !String(c[0]).includes('/verification/'))).toBe(true);
+  });
+});


### PR DESCRIPTION
Reported straight after the first real identity confirmation: confirm, refresh, and the Identity tab says **not confirmed** again.

## Cause

`confirmed` was component state, set by the modal's callback. Nothing read it back. The grant was real — it's on the user in the verification service — but the page only knew about it if you were the session that made it.

## Fix

Read it from `GET /verification/:userId/history` for `pitch.provisioned_user_id`; its `verified` field is the current state. `confirmIdentity` now invalidates `['verification']` as well as `['pitches']`, since the grant lands on the **user**, not the pitch — invalidating only pitches left a stale "not confirmed" even before the refresh.

## Two things it deliberately doesn't do

- **No mock fallback.** `VerificationTool` falls back to `mockVerificationHistory` when the query is empty, which is fine on a browsing surface and wrong here: inventing a confirmation is worse than showing none when the question is whether a badge was granted.
- **Keyed on live data only.** This page falls back to a sample pitch when the API has nothing, and one of those samples carries `provisioned_user_id: 'usr_2f19bc'`. Querying verification for a fabricated id would answer a real question with invented data. A test pins that no `/verification/` call is made when the pitch is a sample.

## Note on that last test

It initially failed for a reason worth recording: `client.get`'s call history accumulates across tests in the file, so it saw `/verification/usr_7/history` from the two tests above it. The assertion now resets the mock first, since the claim is about what *this* render asks for.

`npm test` (269), lint, typecheck, build pass. Playbook updated.