### PR TITLE
Say "re-pitch unavailable" only where it means something

### DIFF
--- a/src/pages/concierge/PitchDetailPage.jsx
+++ b/src/pages/concierge/PitchDetailPage.jsx
@@ -10,9 +10,9 @@ import {
   AUTOMATIC_STATUSES,
   canConfirmIdentity,
   canEditItems,
-  canRepitch,
   canTakedown,
   offeredTransitions,
+  shouldExplainRepitch,
 } from './pitchRules';
 import { mockPitchDetail } from './mockPitches';
 import PitchBuilder from './PitchBuilder';
@@ -187,7 +187,7 @@ export default function PitchDetailPage() {
               {AUTOMATIC_STATUSES.includes(next) ? ' (repair)' : ''}
             </Button>
           ))}
-          {pitch.status !== 'draft' && !canRepitch(pitch) && pitch.status !== 'archived' && (
+          {shouldExplainRepitch(pitch) && (
             <span className="text-[11px] text-gray-400">
               Re-pitch unavailable — the server has not marked this target re-pitchable.
             </span>

--- a/src/pages/concierge/pitchRules.test.js
+++ b/src/pages/concierge/pitchRules.test.js
@@ -19,6 +19,8 @@ import {
   tokenIssueBlockedReason,
   typeMatchesPitch,
   inviteClaimBlockedReason,
+
+  shouldExplainRepitch,
 } from './pitchRules';
 
 const pitch = (over = {}) => ({ status: 'draft', can_repitch: false, ...over });
@@ -245,5 +247,31 @@ describe('inviteClaimBlockedReason — what the server would say', () => {
 
   it('still lets a draft mint tokens, so the preview can be reviewed', () => {
     expect(canIssueTokens(pitch({ status: 'draft' }))).toBe(true);
+  });
+});
+
+describe('shouldExplainRepitch — say it only where it means something', () => {
+  const p = (over = {}) => ({ pitch_id: 'p1', status: 'pitched', can_repitch: false, ...over });
+
+  it('explains it on no_response, the one status a re-pitch would come from', () => {
+    expect(shouldExplainRepitch(p({ status: 'no_response' }))).toBe(true);
+  });
+
+  it('stays quiet on a healthy pitch', () => {
+    // "Re-pitch unavailable" on a pitched or accepted pitch answers a question
+    // nobody asked and reads as an error. It cost an operator time mid-test.
+    for (const status of ['pitched', 'accepted', 'provisioned', 'draft', 'archived']) {
+      expect(shouldExplainRepitch(p({ status })), status).toBe(false);
+    }
+  });
+
+  it('stays quiet on declined, which can only be archived', () => {
+    // The machine offers no path to `pitched` from here, so there is nothing
+    // to explain the absence of.
+    expect(shouldExplainRepitch(p({ status: 'declined' }))).toBe(false);
+  });
+
+  it('says nothing when the server does allow a re-pitch', () => {
+    expect(shouldExplainRepitch(p({ status: 'no_response', can_repitch: true }))).toBe(false);
   });
 });

--- a/src/pages/concierge/pitchRules.ts
+++ b/src/pages/concierge/pitchRules.ts
@@ -150,6 +150,21 @@ export function offeredTransitions(pitch: MaybePitch): PitchStatus[] {
   });
 }
 
+/**
+ * Whether "re-pitch unavailable" is worth saying at all.
+ *
+ * Only where a re-pitch is a move the machine would otherwise allow — which is
+ * `no_response` alone. `declined` can only be archived, and a pitch that is
+ * currently pitched, accepted or provisioned has no business being told that
+ * re-pitching is off: it answers a question nobody asked and reads as an error
+ * on a perfectly healthy pitch.
+ */
+export function shouldExplainRepitch(pitch: MaybePitch): boolean {
+  if (!pitch || pitch.status === 'draft') return false;
+  if (!allowedTransitions(pitch.status).includes('pitched')) return false;
+  return !canRepitch(pitch);
+}
+
 /** PUT /pitches/:id/items 409s once a pitch is provisioned or archived. */
 export function canEditItems(pitch: MaybePitch): boolean {
   if (!pitch) return false;


### PR DESCRIPTION
Found by an operator stopping mid-test to ask about it:

> Re-pitch unavailable — the server has not marked this target re-pitchable.

It's informational and blocks nothing, but it rendered on **every** non-draft, non-archived pitch whose target isn't flagged re-pitchable — so on ordinary `pitched`, `accepted` and `provisioned` pitches, where re-pitching isn't a thing anyone was considering. On a healthy pitch it reads as an error.

`TRANSITIONS` allows `pitched` as a next status only from `draft` and `no_response`; `declined` can only be archived. So `no_response` is the one status where a re-pitch is a move the machine would otherwise offer, and therefore the one place its absence is worth explaining.

`shouldExplainRepitch()` derives that from the transition table rather than restating it, so a change to the machine can't leave this note behind.

`npm test` (273), lint, typecheck, build pass.