### PR TITLE
Stop calling the item note internal, because it isn't

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -268,6 +268,20 @@ The thumbnail box is rendered whether or not there is an image. Hiding a failed 
 when a whole source can fail at once: a hotlink-blocked list would degrade into something that looks
 deliberately text-only, and nobody reports what they cannot see.
 
+## The item note is not internal
+
+`PitchBuilder`'s per-row note is copied verbatim into `list_items.note` at provisioning and rendered on
+the target's own list — and published with it if they publish. The field's placeholder said
+**"Note for this row (internal)"**, which is the opposite of true, and a staff note written under that
+promise reached a claimed list as *"[#553: cleared a TVSeries mismatch on a Movie pitch; re-resolve to
+Bergman's Persona (1966)]"*, italicised under Persona.
+
+It now carries the same **target sees this** marker as the intake fields. Internal working notes belong
+on the pitch itself, under Edit details — `pitch_lists.notes` is staff-only and is not copied anywhere.
+
+Worth checking existing pitches for notes written while the label was wrong; provisioning will carry them
+across.
+
 ## Two item counts that are both right
 
 The admin and the invite page count different things, and neither is wrong:

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -1237,12 +1237,33 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                   </Button>
                 </div>
               )}
-              <TextInput
-                className="mt-2"
-                value={focusedRow.note || ''}
-                onChange={e => patchRow(focus, { note: e.target.value })}
-                placeholder="Note for this row (internal)"
-              />
+              {/* Not internal, whatever it used to say. Provisioning copies this
+                  straight into list_items.note, so it is rendered on the
+                  target's own list and published with it. A staff note written
+                  here reached a claimed list reading "[#553: cleared a TVSeries
+                  mismatch on a Movie pitch; re-resolve to Bergman's Persona
+                  (1966)]". Internal working notes belong on the pitch, under
+                  Edit details. */}
+              <div className="mt-2">
+                <label
+                  htmlFor="row_note"
+                  className="mb-1 block text-[11px] font-medium text-gray-500"
+                >
+                  Note on this item
+                  <span
+                    className="ml-1 rounded bg-indigo-50 px-1 py-0.5 align-middle text-[10px] font-medium text-indigo-700"
+                    title="Copied onto their list when they claim the draft, and published with it"
+                  >
+                    target sees this
+                  </span>
+                </label>
+                <TextInput
+                  id="row_note"
+                  value={focusedRow.note || ''}
+                  onChange={e => patchRow(focus, { note: e.target.value })}
+                  placeholder="A line about this pick, in their voice — not a working note"
+                />
+              </div>
               <div className="mt-2 text-[11px] text-gray-400">
                 Resolving as <span className="font-medium text-gray-500">{thingType}</span>
                 {focusedRow.reason && <> · server said <span className="text-gray-500">{focusedRow.reason}</span></>}

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -792,3 +792,42 @@ describe('builder — cover art on the candidates', () => {
     expect(screen.getAllByRole('presentation', { hidden: true })).toHaveLength(2);
   });
 });
+
+describe('builder — the item note is not internal', () => {
+  const row = [{
+    raw_text: 'Persona (1966) 🇸🇪 8.6/10', thing_id: 'movie_persona_1966', status: 'resolved',
+    candidates: [], match: { title: 'Persona', type: 'Movie', year: 1966 },
+    note: '', dropped: false, confidence: 1, reason: null,
+  }];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.put.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+    client.put.mockResolvedValue({ data: { success: true, item_count: 1 } });
+    sessionStorage.setItem('pitchDraft:p_note', JSON.stringify({ v: 1, savedAt: Date.now(), rows: row }));
+  });
+
+  it('says the target sees it, because provisioning copies it onto their list', () => {
+    // It said "internal". A staff note written under that promise reached a
+    // claimed list reading "[#553: cleared a TVSeries mismatch…]", italicised
+    // under Persona, ready to publish.
+    renderWithProviders(<PitchBuilder pitchId="p_note" thingType="Movie" items={[]} />);
+    const label = screen.getByText(/Note on this item/i);
+    expect(label.textContent).toMatch(/target sees this/i);
+    expect(screen.queryByPlaceholderText(/internal/i)).toBeNull();
+  });
+
+  it('still sends whatever the operator wrote', () => {
+    renderWithProviders(<PitchBuilder pitchId="p_note" thingType="Movie" items={[]} />);
+    fireEvent.change(screen.getByPlaceholderText(/in their voice/i), {
+      target: { value: 'The one that made me want to make films.' },
+    });
+    fireEvent.click(screen.getByRole('button', { name: /save items/i }));
+
+    return vi.waitFor(() => {
+      expect(client.put).toHaveBeenCalled();
+      expect(client.put.mock.calls[0][1].items[0].note).toBe('The one that made me want to make films.');
+    });
+  });
+});


### PR DESCRIPTION
Found on the first claim of a pitch that had operator notes on it. The claimed list arrived looking like this:

> **2. Persona** — *"[#553: cleared a TVSeries mismatch on a Movie pitch; re-resolve to Bergman's Persona (1966)]"*

An issue number and staff working notes, italicised under a film, on a stranger's own list, one button away from being public.

## Mechanism

```sql
INSERT INTO list_items (list_id, thing_id, position, note) VALUES ($1,$2,$3,$4)
  [listId, item.thing_id, position++, item.note || null]
```

Provisioning copies the pitch item's `note` verbatim. That's the design — a per-item note is an ordinary list feature.

The bug is ours. The builder's field said:

> **Note for this row (internal)**

It is the opposite of internal, and this is worse than the `raw_text` leak it echoes: that one happened by omission, while this field *invited* the note and promised it was private.

## Fix

Same **target sees this** marker as the intake fields, and a placeholder that asks for the right thing — *"A line about this pick, in their voice — not a working note"*.

Internal notes already have a home: `pitch_lists.notes`, under Edit details, which is staff-only and copied nowhere.

## Worth doing separately

Existing pitches may carry notes written while the label was wrong. Provisioning will carry them across, so they're worth a sweep before any real outreach — a note written for us reads very differently on someone's own list.

`npm test` (275), lint, typecheck, build pass. Playbook updated.