### PR TITLE
Show item notes in the table, and count them

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -279,8 +279,17 @@ Bergman's Persona (1966)]"*, italicised under Persona.
 It now carries the same **target sees this** marker as the intake fields. Internal working notes belong
 on the pitch itself, under Edit details — `pitch_lists.notes` is staff-only and is not copied anywhere.
 
+Notes now render in the table under the pasted text, and the summary counts them — they used to appear
+only in the focused-row editor, which is how one written weeks earlier on row 2 of 11 stayed invisible
+until it surfaced on a stranger's list. Nobody re-reads eleven rows one at a time to check their own
+notes.
+
 Worth checking existing pitches for notes written while the label was wrong; provisioning will carry them
-across.
+across, and they are now visible at a glance.
+
+There is deliberately no *internal* per-row note: the field is target-facing by design, and inventing a
+second one client-side would be a place to write things that quietly aren't saved. Requested properly in
+listgem-platform#572.
 
 ## Two item counts that are both right
 

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -767,6 +767,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
     return () => window.removeEventListener('keydown', onKey);
   }, []);
 
+  const noted = rows.reduce((a, r, i) => (!r.dropped && r.note?.trim() ? [...a, i] : a), []);
   const unresolvedIndices = rows.reduce((a, r, i) => (!r.dropped && r.status !== 'resolved' ? [...a, i] : a), []);
   const pending = pendingIndices(rows);
 
@@ -776,7 +777,17 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
       key: 'raw',
       header: 'Pasted text',
       render: row => (
-        <span className={row.dropped ? 'text-gray-400 line-through' : 'text-gray-800'}>{row.raw_text}</span>
+        <>
+          <span className={row.dropped ? 'text-gray-400 line-through' : 'text-gray-800'}>{row.raw_text}</span>
+          {/* Notes were visible only in the focused-row editor, so one written
+              weeks earlier on row 2 of 11 was invisible until it appeared on
+              the target's own list. The set has to be readable at a glance. */}
+          {row.note?.trim() && (
+            <span className="mt-0.5 block truncate text-[11px] italic text-indigo-700" title={row.note}>
+              “{row.note.trim()}” — they see this
+            </span>
+          )}
+        </>
       ),
     },
     {
@@ -953,6 +964,11 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         )}
         {duplicates.length > 0 && (
           <span className="font-medium text-amber-600 tabular-nums">{duplicates.length} duplicate</span>
+        )}
+        {noted.length > 0 && (
+          <span className="tabular-nums text-indigo-700" title={`Row ${noted.map(i => i + 1).join(', ')} carry a note copied onto their list`}>
+            {noted.length} with a note they see
+          </span>
         )}
         <button
           onClick={async () => {

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -831,3 +831,45 @@ describe('builder — the item note is not internal', () => {
     });
   });
 });
+
+describe('builder — notes are visible without hunting for them', () => {
+  const rows = [
+    { raw_text: 'Fanny & Alexander (1982) 🇸🇪 9.1/10', thing_id: 'movie_fa', status: 'resolved', candidates: [], match: { title: 'Fanny and Alexander', type: 'Movie', year: 1982 }, note: '', dropped: false, confidence: 1, reason: null },
+    { raw_text: 'Persona (1966) 🇸🇪 8.6/10', thing_id: 'movie_p', status: 'resolved', candidates: [], match: { title: 'Persona', type: 'Movie', year: 1966 }, note: '[#553: cleared a TVSeries mismatch on a Movie pitch]', dropped: false, confidence: 1, reason: null },
+  ];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+    sessionStorage.setItem('pitchDraft:p_notes', JSON.stringify({ v: 1, savedAt: Date.now(), rows }));
+  });
+
+  it('shows the note in the row, not only when that row is focused', () => {
+    // Focused-row-only is how a working note survived to a stranger's list:
+    // nobody scrolls eleven rows one at a time to re-read their own notes.
+    renderWithProviders(<PitchBuilder pitchId="p_notes" thingType="Movie" items={[]} />);
+    const note = screen.getByText(/#553: cleared a TVSeries mismatch/);
+    expect(note.textContent).toMatch(/they see this/i);
+  });
+
+  it('counts them in the summary, so the total is visible before saving', () => {
+    renderWithProviders(<PitchBuilder pitchId="p_notes" thingType="Movie" items={[]} />);
+    expect(screen.getByText(/1 with a note they see/i)).toBeTruthy();
+  });
+
+  it('says nothing about rows with no note', () => {
+    sessionStorage.setItem('pitchDraft:p_clean', JSON.stringify({
+      v: 1, savedAt: Date.now(), rows: [{ ...rows[0] }],
+    }));
+    renderWithProviders(<PitchBuilder pitchId="p_clean" thingType="Movie" items={[]} />);
+    expect(screen.queryByText(/with a note they see/i)).toBeNull();
+  });
+
+  it('ignores a note on a dropped row, which is not going anywhere', () => {
+    sessionStorage.setItem('pitchDraft:p_dropped', JSON.stringify({
+      v: 1, savedAt: Date.now(), rows: [{ ...rows[1], dropped: true }],
+    }));
+    renderWithProviders(<PitchBuilder pitchId="p_dropped" thingType="Movie" items={[]} />);
+    expect(screen.queryByText(/with a note they see/i)).toBeNull();
+  });
+});


### PR DESCRIPTION
Follow-on to #67, in answer to a fair challenge: relabelling the field was a warning, not a fix.

## What was still broken

The note still travels to the target's list — that's by design, a per-item note is an ordinary list feature. But the operator's only view of it was the **focused-row editor**. A note written weeks earlier on row 2 of 11 was invisible in practice, because nobody re-reads eleven rows one at a time to check their own notes.

That's how `"[#553: cleared a TVSeries mismatch on a Movie pitch…]"` survived to a claimed list, italicised under Persona, one button from public.

## What changes

- **Notes render in the row**, under the pasted text, marked *"— they see this"*.
- **The summary counts them**: `1 with a note they see`, with the row numbers on hover, so the total is legible before saving rather than discoverable by scrolling.
- Notes on dropped rows are ignored — they go nowhere.

## What this deliberately doesn't do

Invent an internal per-row note. The field is target-facing by design, and a second field the admin stores nowhere would be a place to write things that quietly aren't saved. Requested properly as listgem-platform#572 — an operator who needs a working note per row currently has to put it somewhere the target will read.

`npm test` (279), lint, typecheck, build pass. Playbook updated.