### PR TITLE
Give the working note somewhere to go

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -287,9 +287,14 @@ notes.
 Worth checking existing pitches for notes written while the label was wrong; provisioning will carry them
 across, and they are now visible at a glance.
 
-There is deliberately no *internal* per-row note: the field is target-facing by design, and inventing a
-second one client-side would be a place to write things that quietly aren't saved. Requested properly in
-listgem-platform#572.
+`internal_note` is the working note — staff only, copied nowhere: not to the claimed list, not into the
+preview payload, not into the invite sample, and guarded server-side at all three
+(listgem-platform#572/#573). It exists because with only `note` a working note either went to the target
+or never got written. Both render in the row, distinctly, and the summary counts only the one the target
+reads.
+
+A dropped heading row's explanation ("Column headings, not an item.") is an internal note for the same
+reason — it is for us, and it used to sit in the field that travels.
 
 ## Two item counts that are both right
 

--- a/src/pages/concierge/PitchBuilder.jsx
+++ b/src/pages/concierge/PitchBuilder.jsx
@@ -412,6 +412,7 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
         candidates: [],
         match,
         note: '',
+        internal_note: '',
         dropped: false,
         confidence: null,
         reason: null,
@@ -785,6 +786,11 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
           {row.note?.trim() && (
             <span className="mt-0.5 block truncate text-[11px] italic text-indigo-700" title={row.note}>
               “{row.note.trim()}” — they see this
+            </span>
+          )}
+          {row.internal_note?.trim() && (
+            <span className="mt-0.5 block truncate text-[11px] text-gray-400" title={row.internal_note}>
+              {row.internal_note.trim()} — internal
             </span>
           )}
         </>
@@ -1278,6 +1284,21 @@ export default function PitchBuilder({ pitchId, thingType, items, readOnly, read
                   value={focusedRow.note || ''}
                   onChange={e => patchRow(focus, { note: e.target.value })}
                   placeholder="A line about this pick, in their voice — not a working note"
+                />
+              </div>
+              {/* The working note now has somewhere to go. Without it, "why did
+                  this row match something odd" either went to the target or
+                  never got written. */}
+              <div className="mt-2">
+                <label htmlFor="row_internal_note" className="mb-1 block text-[11px] font-medium text-gray-500">
+                  Internal note
+                  <span className="ml-1 text-[10px] font-normal text-gray-400">staff only — copied nowhere</span>
+                </label>
+                <TextInput
+                  id="row_internal_note"
+                  value={focusedRow.internal_note || ''}
+                  onChange={e => patchRow(focus, { internal_note: e.target.value })}
+                  placeholder="Why this row needed work, what to re-check…"
                 />
               </div>
               <div className="mt-2 text-[11px] text-gray-400">

--- a/src/pages/concierge/PitchBuilder.test.jsx
+++ b/src/pages/concierge/PitchBuilder.test.jsx
@@ -4,6 +4,7 @@ import { fireEvent, screen } from '@testing-library/react';
 import { renderWithProviders } from '../../test/utils';
 import client from '../../api/client';
 import PitchBuilder from './PitchBuilder';
+import { normalizeParsed, rowsFromParsed } from './resolveAdapter';
 
 vi.mock('../../api/client', () => ({
   default: { get: vi.fn(), post: vi.fn(), put: vi.fn(), patch: vi.fn(), delete: vi.fn() },
@@ -871,5 +872,71 @@ describe('builder — notes are visible without hunting for them', () => {
     }));
     renderWithProviders(<PitchBuilder pitchId="p_dropped" thingType="Movie" items={[]} />);
     expect(screen.queryByText(/with a note they see/i)).toBeNull();
+  });
+});
+
+describe('builder — the two notes are told apart', () => {
+  const rows = [{
+    raw_text: 'Persona (1966) 🇸🇪 8.6/10', thing_id: 'movie_p', status: 'resolved', candidates: [],
+    match: { title: 'Persona', type: 'Movie', year: 1966 },
+    note: 'The one that made me want to make films.',
+    internal_note: '[#553: cleared a TVSeries mismatch on a Movie pitch]',
+    dropped: false, confidence: 1, reason: null,
+  }];
+
+  beforeEach(() => {
+    client.get.mockReset();
+    client.put.mockReset();
+    client.get.mockRejectedValue(new Error('no search'));
+    client.put.mockResolvedValue({ data: { success: true, item_count: 1 } });
+    sessionStorage.setItem('pitchDraft:p_two', JSON.stringify({ v: 1, savedAt: Date.now(), rows }));
+  });
+
+  it('sends both, on the fields that mean what they say', () => {
+    // The working note used to have nowhere to go but the field the target
+    // reads, which is how "[#553: cleared a TVSeries mismatch…]" reached a
+    // stranger's list.
+    renderWithProviders(<PitchBuilder pitchId="p_two" thingType="Movie" items={[]} />);
+    fireEvent.click(screen.getByRole('button', { name: /save items/i }));
+
+    return vi.waitFor(() => {
+      const sent = client.put.mock.calls[0][1].items[0];
+      expect(sent.note).toBe('The one that made me want to make films.');
+      expect(sent.internal_note).toBe('[#553: cleared a TVSeries mismatch on a Movie pitch]');
+    });
+  });
+
+  it('marks only the target-visible one as target-visible', () => {
+    renderWithProviders(<PitchBuilder pitchId="p_two" thingType="Movie" items={[]} />);
+    expect(screen.getByText(/Note on this item/i).textContent).toMatch(/target sees this/i);
+    expect(screen.getByText(/^Internal note/i).textContent).toMatch(/copied nowhere/i);
+  });
+
+  it('counts the note the target reads', () => {
+    renderWithProviders(<PitchBuilder pitchId="p_two" thingType="Movie" items={[]} />);
+    expect(screen.getByText(/1 with a note they see/i)).toBeTruthy();
+  });
+
+  it('does not count an internal note, which is nobody else\'s business', () => {
+    // Separate test rather than a second render: the first stays mounted, and
+    // the assertion would find its summary instead of this one's.
+    sessionStorage.setItem('pitchDraft:p_int', JSON.stringify({
+      v: 1, savedAt: Date.now(), rows: [{ ...rows[0], note: '' }],
+    }));
+    renderWithProviders(<PitchBuilder pitchId="p_int" thingType="Movie" items={[]} />);
+    expect(screen.queryByText(/with a note they see/i)).toBeNull();
+    expect(screen.getByText(/#553: cleared a TVSeries mismatch/)).toBeTruthy();
+  });
+
+  it('keeps a dropped heading row\'s explanation off the target\'s list', () => {
+    // rowsFromParsed writes that explanation, and it is for us.
+    const parsed = rowsFromParsed(normalizeParsed([
+      'Rank Film Year Worldwide gross Ref',
+      '1 It 2017 $719,766,009 [1][2]',
+      '2 The Sixth Sense 1999 $672,806,292 [3][4]',
+      '3 I Am Legend 2007 $585,532,684 [5][6]',
+    ]));
+    expect(parsed[0].note).toBe('');
+    expect(parsed[0].internal_note).toMatch(/Column headings/);
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -67,7 +67,10 @@ export interface BuilderRow {
   status: RowStatus;
   candidates: Candidate[];
   match: Candidate | null;
+  /** Copied onto the target's list at provisioning, and published with it. */
   note: string;
+  /** Staff only — never copied anywhere (listgem-platform#572). */
+  internal_note: string;
   dropped: boolean;
   confidence: number | null;
   reason: string | null;
@@ -119,6 +122,14 @@ export interface ItemPayload {
   thing_id: string | null;
   resolution_status: 'resolved' | 'ambiguous';
   note: string | null;
+  /**
+   * The operator's working note. Kept on the pitch and copied nowhere: not to
+   * the claimed list, not into the preview payload, not into the invite
+   * sample. Exists because with only `note` — which the target reads — a
+   * working note either went to them or never got written
+   * (listgem-platform#572).
+   */
+  internal_note: string | null;
   /**
    * A line safe to show the target (listgem-platform#565).
    *
@@ -573,6 +584,7 @@ export function toItemsPayload(rows: BuilderRow[]): ItemPayload[] {
       thing_id: row.thing_id || null,
       resolution_status: row.thing_id ? 'resolved' : 'ambiguous',
       note: row.note?.trim() ? row.note.trim() : null,
+      internal_note: row.internal_note?.trim() ? row.internal_note.trim() : null,
       // Null rather than an empty string when there is nothing to show: the
       // server treats null as "no display line", and an unlabelled chip beats
       // a blank one.
@@ -733,7 +745,10 @@ export function rowsFromParsed(parsed: ParsedCandidate[]): BuilderRow[] {
     match: null,
     // Dropped rather than removed: it stays visible and struck through, and
     // one keystroke puts it back if the guess was wrong.
-    note: queries[i].header ? 'Column headings, not an item.' : '',
+    note: '',
+    // The heading explanation is for us, not for the target — it would
+    // otherwise ride onto their list under a row we already dropped.
+    internal_note: queries[i].header ? 'Column headings, not an item.' : '',
     dropped: queries[i].header,
     confidence: null,
     reason: null,
@@ -781,6 +796,7 @@ export function rowsFromItems(items: unknown): BuilderRow[] {
         candidates: [],
         match: match?.thing_id || match?.title !== '(untitled)' ? match : null,
         note: typeof it.note === 'string' ? it.note : '',
+        internal_note: typeof it.internal_note === 'string' ? it.internal_note : '',
         dropped: false,
         confidence: null,
         reason: null,


### PR DESCRIPTION
The admin half of listgem-platform#572, whose server half is their PR #573.

**Do not merge until #573 is deployed.** Until the column exists this ships a field that looks saved and isn't — which is precisely the failure mode it was built to avoid.

## What changes

Rows carry `internal_note` beside `note`:

| field | who reads it | where it goes |
|---|---|---|
| `note` | the target | copied to `list_items.note`, published with the list |
| `internal_note` | staff | nowhere — guarded server-side at provisioning, preview and invite sample |

Both render in the table row, told apart by who reads them. The summary counts **only** the target-visible one; an internal note isn't something to warn anyone about.

## One thing that moved

`rowsFromParsed` wrote *"Column headings, not an item."* into `note` for an auto-dropped heading row. That explanation is for us, and it was sitting in the field that travels. It's now an internal note.

## On whose bug it was

The backend session has claimed the leaked Persona note, having written it during the #553 repair, and has already moved it to `internal_note` in prod. Worth being accurate about the split: the note was theirs, the field labelled **"Note for this row (internal)"** was ours, and it took both. A field that lies about where its contents go will eventually be believed by someone.

`npm test` (284), lint, typecheck, build pass. Playbook updated.