### PR TITLE
Tell the operator when the tab is behind what's deployed

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -268,6 +268,21 @@ The thumbnail box is rendered whether or not there is an image. Hiding a failed 
 when a whole source can fail at once: a hotlink-blocked list would degrade into something that looks
 deliberately text-only, and nobody reports what they cannot see.
 
+## Stale tabs
+
+`UpdateBanner` compares the fingerprinted entry bundle this tab loaded against the one `/index.html` is
+serving now, on a five-minute timer and on window focus, and offers a reload when they differ. Dev has no
+fingerprint, so it does nothing there; an unreachable check says nothing and stays quiet, because nagging
+after a failed fetch teaches people to ignore the one message that matters.
+
+It exists because an operator worked across three deploys in one tab and hit a bug that had already been
+fixed: the item-note field still said **"internal"** in their build, they believed it, and the note
+reached a stranger's list. The guards are most of what this tool is, and a stale tab has the old ones
+while looking identical.
+
+Not a forced reload — the builder can hold unsaved rows. Drafts survive a reload now, so the cost of
+saying yes is low, but it stays the operator's call.
+
 ## The item note is not internal
 
 `PitchBuilder`'s per-row note is copied verbatim into `list_items.note` at provisioning and rendered on

--- a/src/api/appVersion.js
+++ b/src/api/appVersion.js
@@ -1,0 +1,46 @@
+/**
+ * Whether the tab is running the build that's currently deployed.
+ *
+ * An operator kept a builder tab open across three deploys and worked against
+ * a field whose label had since been corrected — the one that used to say a
+ * note was internal when it was copied onto the target's list. They followed
+ * the label, and the note reached a stranger's list. The guards are most of
+ * this tool's value, and a stale tab silently has the old ones.
+ *
+ * Vite fingerprints the entry bundle, so the filename in index.html IS the
+ * build id. No build-time config, nothing to keep in sync.
+ */
+
+/** The hashed entry bundle named by a copy of index.html. */
+export function parseAssetId(html) {
+  const m = String(html || '').match(/\/assets\/(index-[A-Za-z0-9_-]+\.js)/);
+  return m ? m[1] : null;
+}
+
+/** The one this tab actually loaded. */
+export function loadedAssetId(doc = document) {
+  for (const el of doc.querySelectorAll('script[src]')) {
+    const id = parseAssetId(el.getAttribute('src'));
+    if (id) return id;
+  }
+  return null;
+}
+
+/**
+ * Ask the origin what it's serving now. `no-store` matters: a cached copy of
+ * index.html would report the build we already have, forever.
+ */
+export async function fetchDeployedAssetId(fetchImpl = fetch) {
+  const res = await fetchImpl('/index.html', { cache: 'no-store' });
+  if (!res.ok) throw new Error(`index.html ${res.status}`);
+  return parseAssetId(await res.text());
+}
+
+/**
+ * True only when both ids are known and differ. Unknown is never "stale":
+ * nagging someone to reload because a fetch failed would train them to ignore
+ * the one message that matters.
+ */
+export function isStale(loaded, deployed) {
+  return !!loaded && !!deployed && loaded !== deployed;
+}

--- a/src/api/appVersion.test.js
+++ b/src/api/appVersion.test.js
@@ -1,0 +1,45 @@
+import { describe, expect, it, vi } from 'vitest';
+import { fetchDeployedAssetId, isStale, loadedAssetId, parseAssetId } from './appVersion';
+
+const HTML = `<!doctype html><html><head>
+  <script type="module" crossorigin src="/assets/index-DDsq6xfd.js"></script>
+  <link rel="stylesheet" href="/assets/index-BqT1.css">
+</head><body><div id="root"></div></body></html>`;
+
+describe('appVersion', () => {
+  it('reads the fingerprinted bundle as the build id', () => {
+    expect(parseAssetId(HTML)).toBe('index-DDsq6xfd.js');
+  });
+
+  it('returns null when there is nothing to read', () => {
+    expect(parseAssetId('<html></html>')).toBeNull();
+    expect(parseAssetId('')).toBeNull();
+    expect(parseAssetId(null)).toBeNull();
+  });
+
+  it('finds the bundle this tab loaded', () => {
+    const doc = new DOMParser().parseFromString(HTML, 'text/html');
+    expect(loadedAssetId(doc)).toBe('index-DDsq6xfd.js');
+  });
+
+  it('asks the origin without a cache, or it would report our own build forever', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: true, text: async () => HTML });
+    await expect(fetchDeployedAssetId(fetchImpl)).resolves.toBe('index-DDsq6xfd.js');
+    expect(fetchImpl).toHaveBeenCalledWith('/index.html', { cache: 'no-store' });
+  });
+
+  it('throws rather than guessing when the origin errors', async () => {
+    const fetchImpl = vi.fn().mockResolvedValue({ ok: false, status: 503 });
+    await expect(fetchDeployedAssetId(fetchImpl)).rejects.toThrow(/503/);
+  });
+
+  it('calls a tab stale only when both ids are known and differ', () => {
+    expect(isStale('index-a.js', 'index-b.js')).toBe(true);
+    expect(isStale('index-a.js', 'index-a.js')).toBe(false);
+    // Unknown is never stale: nagging someone because a fetch failed teaches
+    // them to ignore the one message that matters.
+    expect(isStale(null, 'index-b.js')).toBe(false);
+    expect(isStale('index-a.js', null)).toBe(false);
+    expect(isStale(null, null)).toBe(false);
+  });
+});

--- a/src/components/AppShell.jsx
+++ b/src/components/AppShell.jsx
@@ -1,13 +1,19 @@
 import { Outlet } from 'react-router-dom';
 import Sidebar from './Sidebar';
+import UpdateBanner from './UpdateBanner';
 
 export default function AppShell() {
   return (
     <div className="flex min-h-screen bg-gray-50">
       <Sidebar />
-      <main className="flex-1 p-6 overflow-auto">
-        <Outlet />
-      </main>
+      <div className="flex min-w-0 flex-1 flex-col">
+        {/* Above everything: a stale tab has stale guards, and the guards are
+            most of what this tool is. */}
+        <UpdateBanner />
+        <main className="flex-1 overflow-auto p-6">
+          <Outlet />
+        </main>
+      </div>
     </div>
   );
 }

--- a/src/components/UpdateBanner.jsx
+++ b/src/components/UpdateBanner.jsx
@@ -1,0 +1,60 @@
+import { useEffect, useState } from 'react';
+import { fetchDeployedAssetId, isStale, loadedAssetId } from '../api/appVersion';
+
+const CHECK_EVERY_MS = 5 * 60 * 1000;
+
+/**
+ * Tells the operator when the tab is behind what's deployed.
+ *
+ * Not a forced reload: a builder can hold unsaved rows, and taking the page
+ * out from under someone mid-adjudication would be its own bug. Drafts do
+ * survive a reload now, so the cost of saying yes is low — but it stays their
+ * call.
+ */
+export default function UpdateBanner() {
+  const [stale, setStale] = useState(false);
+
+  useEffect(() => {
+    // Dev serves no fingerprinted bundle, so there is nothing to compare.
+    if (!import.meta.env.PROD) return undefined;
+    const loaded = loadedAssetId();
+    if (!loaded) return undefined;
+
+    let cancelled = false;
+    async function check() {
+      try {
+        const deployed = await fetchDeployedAssetId();
+        if (!cancelled && isStale(loaded, deployed)) setStale(true);
+      } catch {
+        // Offline, or the origin hiccupped. Silence is right: an unreachable
+        // check says nothing about which build is deployed.
+      }
+    }
+    check();
+    const timer = setInterval(check, CHECK_EVERY_MS);
+    // A tab left open for hours is exactly the case this exists for, and it
+    // wakes up when someone comes back to it.
+    window.addEventListener('focus', check);
+    return () => {
+      cancelled = true;
+      clearInterval(timer);
+      window.removeEventListener('focus', check);
+    };
+  }, []);
+
+  if (!stale) return null;
+  return (
+    <div className="flex items-center gap-3 border-b border-amber-200 bg-amber-50 px-4 py-2 text-xs text-amber-900">
+      <span>
+        <span className="font-medium">This page is running an older version.</span> Newer builds change
+        what the controls do and what the warnings say — reload before you rely on them.
+      </span>
+      <button
+        onClick={() => window.location.reload()}
+        className="ml-auto rounded border border-amber-300 bg-white px-2 py-0.5 font-medium hover:bg-amber-100"
+      >
+        Reload
+      </button>
+    </div>
+  );
+}


### PR DESCRIPTION
Found the hard way, minutes ago.

An operator ran the note test and the **internal** note appeared on the claimed list. Our wiring was correct — two fields, two keys, verified in source and in the deployed bundle. The cause was their tab: it had been open across three deploys, so the builder still showed a single unlabelled note box whose placeholder read **"Note for this row (internal)"**.

They followed the label. The label had been wrong, and had been fixed an hour earlier in #67. The fix was live; their tab wasn't.

## What changes

`UpdateBanner` compares the fingerprinted entry bundle this tab loaded against the one `/index.html` serves now — Vite's hash *is* the build id, so there's nothing to configure and nothing to keep in sync. Checked on a five-minute timer and on window focus, since a tab left open for hours is the whole case.

## Decisions

- **Unknown is never stale.** A failed fetch says nothing about what's deployed. Nagging on it would train someone to ignore the one message that matters.
- **Not a forced reload.** The builder can hold unsaved rows, and taking the page out from under someone mid-adjudication would be its own bug. Drafts survive a reload now, so saying yes is cheap — but it stays their call.
- **Silent in dev**, where there's no fingerprint to compare.

## Why this is worth a component

This tool's value is almost entirely its guards: type-mismatch blocking, duplicate blocking, the "target sees this" markers, the invite-not-claimable warning, the implausible-match flag. Every one shipped in the last two days. A stale tab has none of them and looks exactly like a fresh one — and unlike a stale API response, nothing ever contradicts it.

`npm test` (290), lint, typecheck, build pass. Playbook updated.