### PR TITLE
A claimed pitch is not still being built

### DIFF
--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -198,6 +198,15 @@ send, they claim, confirm identity — each `done` / `current` / `blocked` / `wa
 from server state only. `PitchFlowRail` renders it above the tabs and leaves them alone: it helps someone
 who doesn't know the sequence without slowing down someone who does.
 
+A claimed pitch is not still being built. Once `canEditItems` is false the build step settles as done,
+whatever its unresolved count — otherwise the rail read *"Next: Build the list — 2 of 4 rows still
+unresolved"* with a **Finish the list** button, directly above the panel explaining that the item set is
+theirs and the API rejects edits.
+
+The identity step navigates to the tab rather than opening the modal, for the same reason re-issue does:
+the claim timestamp and the provisioned account are there, and a badge should not be granted without
+reading them. It also keeps one "Confirm identity" button per screen.
+
 Three rules hold it together, and each exists because of a specific failure:
 
 - **Exactly one step is live.** A rail that answers "what now" with two answers is not a rail. Pinned by

--- a/src/pages/concierge/PitchDetailPage.test.jsx
+++ b/src/pages/concierge/PitchDetailPage.test.jsx
@@ -296,7 +296,7 @@ describe('pitch detail — a confirmed identity survives a reload', () => {
     serveWith(provisioned, { verified: { type: 'individual', proof: null, since: '2026-08-26T19:05:00Z' }, history: [] });
     renderDetail();
 
-    fireEvent.click(await screen.findByRole('button', { name: /identity/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Identity' }));
     await vi.waitFor(() => expect(screen.getByText(/Identity confirmed for usr_7/i)).toBeTruthy());
   });
 
@@ -304,7 +304,7 @@ describe('pitch detail — a confirmed identity survives a reload', () => {
     serveWith(provisioned, { verified: null, history: [] });
     renderDetail();
 
-    fireEvent.click(await screen.findByRole('button', { name: /identity/i }));
+    fireEvent.click(await screen.findByRole('button', { name: 'Identity' }));
     await vi.waitFor(() => expect(screen.getByRole('button', { name: /confirm identity/i })).toBeTruthy());
     expect(screen.queryByText(/Identity confirmed for/i)).toBeNull();
   });

--- a/src/pages/concierge/pitchFlow.test.js
+++ b/src/pages/concierge/pitchFlow.test.js
@@ -201,3 +201,43 @@ describe('itemCounts — the rows are the truth when we have them', () => {
     expect(currentStep(steps).label).toMatch(/Mark as pitched/i);
   });
 });
+
+describe('pitchFlow — a claimed pitch is not still being built', () => {
+  const claimed = {
+    status: 'provisioned',
+    item_count: 4, resolved_count: 2,
+    preview_token: 'p', invite_token: 'i',
+    invite_used_at: '2026-08-27T14:10:00Z',
+  };
+
+  it('stops asking for a list the API will not accept edits to', () => {
+    // It read "Next: Build the list — 2 of 4 rows still unresolved" with a
+    // "Finish the list" button, directly above the panel saying the item set
+    // is theirs now and edits are rejected.
+    const steps = flow(claimed);
+    const build = steps.find(s => s.id === 'build');
+    expect(build.state).toBe('done');
+    expect(build.detail).toMatch(/2 of 4 item\(s\) resolved/);
+    expect(build.detail).toMatch(/theirs now/i);
+  });
+
+  it('moves on to the step that is actually available', () => {
+    const step = live(claimed);
+    expect(step.label).toMatch(/Confirm identity/i);
+    // Sends you to the tab rather than opening the modal: the claim timestamp
+    // and provisioned account are there, and a badge should not be granted
+    // without them. It also keeps one "Confirm identity" button per screen.
+    expect(step.action).toEqual({ kind: 'tab', tab: 'identity', label: 'Open Identity' });
+  });
+
+  it('offers viewing rather than finishing', () => {
+    expect(flow(claimed).find(s => s.id === 'build').action)
+      .toEqual({ kind: 'tab', tab: 'build', label: 'View the list' });
+  });
+
+  it('still holds an editable pitch at the build step', () => {
+    // The guard is about editability, not about unresolved rows.
+    const open = { ...claimed, status: 'pitched', invite_used_at: null };
+    expect(live(open).label).toMatch(/Build the list/i);
+  });
+});

--- a/src/pages/concierge/pitchFlow.ts
+++ b/src/pages/concierge/pitchFlow.ts
@@ -15,6 +15,7 @@
 
 import {
   canConfirmIdentity,
+  canEditItems,
   inviteClaimBlockedReason,
   isExpired,
   type MaybePitch,
@@ -155,19 +156,30 @@ export function pitchFlow(
 
   // 2. The list. `item_count`/`resolved_count` are the server's, so this tracks
   //    what is *saved*, never what happens to be on screen unsaved.
+  // Once the target has claimed it, the item set is theirs and the API rejects
+  // edits — so an unresolved row is no longer ours to finish. Left as `current`
+  // this told an operator to "Finish the list" directly above a panel saying
+  // they couldn't, and hid the step that actually was available.
+  const buildOver = !canEditItems(p);
   const buildDetail = items === 0
     ? 'Nothing saved yet — paste the source list and resolve it.'
     : `${items - resolved} of ${items} row(s) still unresolved.`;
   steps.push(
-    step('build', 'Build the list', listReady ? 'done' : 'current',
-      listReady ? `${items} item(s) saved.` : buildDetail,
-      { kind: 'tab', tab: 'build', label: items === 0 ? 'Open the builder' : 'Finish the list' }),
+    step('build', 'Build the list', listReady || buildOver ? 'done' : 'current',
+      buildOver
+        ? `${resolved} of ${items} item(s) resolved. The set is theirs now.`
+        : listReady
+          ? `${items} item(s) saved.`
+          : buildDetail,
+      buildOver
+        ? { kind: 'tab', tab: 'build', label: 'View the list' }
+        : { kind: 'tab', tab: 'build', label: items === 0 ? 'Open the builder' : 'Finish the list' }),
   );
 
   // 3. Links. Both are minted together; the preview is the reason this is
   //    allowed on a draft at all.
   steps.push(
-    step('links', 'Generate the links', hasTokens ? 'done' : listReady ? 'current' : 'todo',
+    step('links', 'Generate the links', hasTokens ? 'done' : listReady && !buildOver ? 'current' : 'todo',
       hasTokens ? 'Preview and invite links exist.' : 'Mints the preview and invite pair.',
       { kind: 'tab', tab: 'outreach', label: hasTokens ? 'Re-issue…' : 'Generate links' },
       hasTokens && previewHref ? { kind: 'link', href: previewHref, label: 'Open preview' } : null),
@@ -247,7 +259,11 @@ export function pitchFlow(
         : canConfirmIdentity(p)
           ? 'Needs evidence a human checked — the claim alone is not proof of identity.'
           : 'Available once the target has claimed and the draft is provisioned.',
-      { kind: 'modal', modal: 'identity', label: 'Confirm identity…' }),
+      // Navigates rather than opening the modal: the Identity tab carries the
+      // claim timestamp and the provisioned account, and the judgement this
+      // grants a badge on should be made after reading them. It also stops two
+      // identically-named buttons sitting on one screen.
+      { kind: 'tab', tab: 'identity', label: 'Open Identity' }),
   );
 
   return firstLiveOnly(steps);


### PR DESCRIPTION
Found by rendering the deployed page headlessly — first pitch I looked at.

On a **provisioned** pitch the rail read:

> **Next: Build the list** — 2 of 4 row(s) still unresolved.  ·  **[ Finish the list ]**

directly above:

> The target has claimed this draft — the item set is theirs now and the API rejects edits.

It asked for something impossible, and in doing so hid the step that *was* available.

## Cause

The build step was `current` whenever `resolved !== item_count`, with no regard for whether the pitch could still be edited. An unresolved row on a claimed pitch isn't ours to finish — it went to the target as an import leftover, which is the designed outcome.

## Fix

`canEditItems` settles the step. Done, whatever the count, with an honest detail — *"2 of 4 item(s) resolved. The set is theirs now."* — and an action that offers viewing rather than finishing. The rail then reaches **Confirm identity**, which is what a provisioned pitch is actually waiting on.

## One more change, for consistency

The identity step now navigates to the Identity tab rather than opening the modal directly. Same call as re-issue in #58: the claim timestamp and provisioned account live on that tab, a badge shouldn't be granted without reading them, and two identically-named "Confirm identity" buttons on one screen is its own ambiguity — which is exactly how the test suite caught this half.

## Note on method

This is the third defect in a row found by looking at the rendered page rather than the code — after the preview rendering `raw_text` and the note field lying about where it goes. All three had passing tests.

`npm test` (294), lint, typecheck, build pass. Playbook updated.