### PR TITLE
One entity, one candidate row

### DIFF
--- a/src/pages/concierge/pitchFlow.ts
+++ b/src/pages/concierge/pitchFlow.ts
@@ -162,7 +162,11 @@ export function pitchFlow(
   // they couldn't, and hid the step that actually was available.
   const buildOver = !canEditItems(p);
   const buildDetail = items === 0
-    ? 'Nothing saved yet — paste the source list and resolve it.'
+    // Covers both states: nothing pasted, and pasted-and-resolved but never
+    // saved. The rail reads the server's counts, so a screen full of resolved
+    // rows still shows zero here, and "paste the source list" alone was stale
+    // advice at exactly the moment Save was the missing step.
+    ? 'Nothing saved yet — paste the source list, resolve it, then Save items.'
     : `${items - resolved} of ${items} row(s) still unresolved.`;
   steps.push(
     step('build', 'Build the list', listReady || buildOver ? 'done' : 'current',

--- a/src/pages/concierge/resolveAdapter.test.js
+++ b/src/pages/concierge/resolveAdapter.test.js
@@ -7,8 +7,8 @@ import {
   normalizeParseOutcome,
   normalizeParsed,
   normalizeCandidate,
-  normalizeResolution,
   normalizeSearchResults,
+  normalizeResolution,
   pendingIndices,
   rowsFromItems,
   rowsFromParsed,
@@ -837,5 +837,43 @@ describe('candidate art — where production actually keeps it', () => {
   it('reports null rather than guessing when there is no art', () => {
     expect(normalizeCandidate({ thing_id: 't', title: 'X', metadata: { backdrop_url: 'https://cdn/b.jpg' } }).image_url)
       .toBeNull();
+  });
+});
+
+describe('search results — one entity, one row', () => {
+  it('drops a repeated thing_id', () => {
+    // /search-to-add returned movie_hannibal_2001_6a2bb8c1 in slots 1 and 2 of
+    // a real query. Two identical rows in a list you choose from read as two
+    // different films.
+    const results = normalizeSearchResults({
+      results: [
+        { thing_id: 'movie_hannibal_2001', title: 'Hannibal', type: 'Movie', year: 2001, in_registry: true },
+        { thing_id: 'movie_hannibal_2001', title: 'Hannibal', type: 'Movie', year: 2001, in_registry: true },
+        { thing_id: 'movie_hannibal_rising_2007', title: 'Hannibal Rising', type: 'Movie', year: 2007, in_registry: true },
+      ],
+    });
+    expect(results.map(r => r.thing_id)).toEqual(['movie_hannibal_2001', 'movie_hannibal_rising_2007']);
+  });
+
+  it('keeps the first occurrence, which is the one the server ranked highest', () => {
+    const results = normalizeSearchResults({
+      results: [
+        { thing_id: 't1', title: 'Best match', type: 'Movie', in_registry: true },
+        { thing_id: 't1', title: 'Same thing, later', type: 'Movie', in_registry: true },
+      ],
+    });
+    expect(results).toHaveLength(1);
+    expect(results[0].title).toBe('Best match');
+  });
+
+  it('leaves federated hits alone, since they carry no id to compare', () => {
+    // Two TMDB rows can legitimately be different films with the same title.
+    const results = normalizeSearchResults({
+      results: [
+        { title: 'Hannibal', type: 'Movie', year: 1959, in_registry: false, source: 'tmdb', source_id: '169818' },
+        { title: 'Hannibal', type: 'Movie', year: 1972, in_registry: false, source: 'tmdb', source_id: '55555' },
+      ],
+    });
+    expect(results).toHaveLength(2);
   });
 });

--- a/src/pages/concierge/resolveAdapter.ts
+++ b/src/pages/concierge/resolveAdapter.ts
@@ -253,7 +253,21 @@ export function normalizeSearchResults(data: unknown): Candidate[] {
     : isObject(data) && Array.isArray(data.results)
       ? data.results
       : [];
-  return list.map(normalizeCandidate).filter((c): c is Candidate => c !== null);
+  const seen = new Set<string>();
+  return list
+    .map(normalizeCandidate)
+    .filter((c): c is Candidate => c !== null)
+    // One entity, one row. /search-to-add returns the same thing_id twice for
+    // some queries — searching "Hannibal" listed movie_hannibal_2001_6a2bb8c1
+    // in the first two slots. Two identical rows in a list you are choosing
+    // from reads as two different films, and it spends a slot in a capped
+    // result set. Federated hits carry no thing_id and are left alone.
+    .filter(c => {
+      if (!c.thing_id) return true;
+      if (seen.has(c.thing_id)) return false;
+      seen.add(c.thing_id);
+      return true;
+    });
 }
 
 /**


### PR DESCRIPTION
From a builder sweep driven headlessly against the deployed app.

## Duplicate candidates

Searching `Hannibal` returned this in the first two slots:

```
LOCAL  2001  Hannibal   movie_hannibal_2001_6a2bb8c1
LOCAL  2001  Hannibal   movie_hannibal_2001_6a2bb8c1
```

Same id, same poster, same year — rendered as two separate choices in the list an operator picks from. Two identical rows read as two different films, which is precisely the confusion the candidate list exists to remove, and it spends a slot in a capped set of twenty.

Deduped on `thing_id`, keeping the first — the one the server ranked highest. **Federated hits are left alone**: they carry no `thing_id`, and two TMDB rows sharing a title can legitimately be different films.

Reported upstream too, since the endpoint shouldn't send it twice. But a candidate list showing one film twice is ours to fix wherever the duplication starts.

## Stale rail advice

On a builder holding four pasted, resolved, unsaved rows, the rail read:

> Next: Build the list — **Nothing saved yet — paste the source list and resolve it.**

The count is right — it reads the server's saved items, and nothing had been saved. The advice was stale: pasting and resolving were done, and **Save items** was the missing step. The copy now names it, and reads correctly in both states.

## Verified in the same sweep

Rendering the builder also confirmed three things that had shipped untested by eye: posters on candidate rows (the `metadata.poster_url` fix), both note fields with their correct labels, and the Discard build control appearing with unsaved changes.

`npm test` (297), lint, typecheck, build pass.