### PR TITLE
Run the suite in CI, and the contract probe on a schedule

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,25 @@
+name: CI
+
+# The suite exists; nothing was running it. 297 tests that only execute when
+# someone remembers are a suite you find out about during a release.
+on:
+  push:
+    branches: [main]
+  pull_request:
+
+jobs:
+  check:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          # jsdom is pinned to ^26 because 27 needs Node >= 20.19 for its
+          # CJS->ESM require chain; 20.x here keeps CI and dev on the same rules.
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+      - run: npm run lint
+      - run: npm run typecheck
+      - run: npm test
+      - run: npm run build

--- a/.github/workflows/contract-check.yml
+++ b/.github/workflows/contract-check.yml
@@ -1,0 +1,36 @@
+name: Contract check
+
+# Asks production whether it still returns the fields this portal reads.
+#
+# On a schedule rather than only at build time, because the failure this is
+# really for comes from *another repo*: when the API removed `raw_text` from
+# the preview payload — a correct change — the website rendered unresolved rows
+# as bare row numbers until its matching change merged. No CI in either repo
+# runs on the other's deploy, so nothing would have noticed.
+#
+# Also dispatchable, so a QA tester can get a verdict without a clone, a Node
+# install, or a developer.
+on:
+  schedule:
+    # Every three hours. Detection latency versus litter: each run creates one
+    # scratch pitch and takes it down, so a tighter cadence leaves more archived
+    # rows behind. Tune here if that trade changes.
+    - cron: '0 */3 * * *'
+  workflow_dispatch:
+
+jobs:
+  contract:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+      - name: Probe production
+        # Email and password, not a token: a JWT lasts 24 hours, so a token in
+        # a secret would report a stale credential as a contract failure by the
+        # next morning. The script refuses to run on an expired one either way.
+        env:
+          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+        run: node scripts/contract-check.mjs

--- a/docs/concierge-admin.md
+++ b/docs/concierge-admin.md
@@ -405,8 +405,16 @@ running on a schedule for that reason, not only before a deploy.
 What it cannot catch: a field labelled "internal" that isn't, or a stale tab serving old guards. Those
 needed judgement about meaning rather than shape.
 
-Needs a credential — `ADMIN_TOKEN` in the environment, or `~/.listgem_admin_cred`. It refuses to run on
-an expired token rather than reporting failures that are really an auth bounce.
+Needs a credential — `ADMIN_TOKEN`, or `ADMIN_EMAIL` + `ADMIN_PASSWORD`, or `~/.listgem_admin_cred`. It
+refuses to run on an expired token rather than reporting failures that are really an auth bounce.
+
+`.github/workflows/contract-check.yml` runs it every three hours and on manual dispatch, so a QA tester
+can get a verdict without a clone or a developer. It uses email + password rather than a token, because a
+JWT lasts 24 hours and a token in a repo secret would report a stale credential as a contract failure by
+the next morning. Needs `ADMIN_EMAIL` and `ADMIN_PASSWORD` repo secrets.
+
+Each run creates one scratch pitch and takes it down, so the cadence trades detection latency against
+archived rows left behind. Three hours is a guess, not a finding.
 
 ## Verifying against prod
 

--- a/scripts/contract-check.mjs
+++ b/scripts/contract-check.mjs
@@ -38,13 +38,29 @@ function check(name, condition, detail) {
   return false;
 }
 
+async function login(email, password) {
+  const res = await fetch(`${API}/auth/login`, {
+    method: 'POST',
+    headers: { 'content-type': 'application/json' },
+    body: JSON.stringify({ email, password }),
+  });
+  if (!res.ok) throw new Error(`login ${res.status}`);
+  return (await res.json()).token;
+}
+
 async function credential() {
   if (process.env.ADMIN_TOKEN) return process.env.ADMIN_TOKEN;
+  // Scheduled runs use email + password, not a token: a JWT lasts 24 hours, so
+  // a token in a repo secret turns a monitor into something that reports a
+  // stale credential as a contract failure the morning after it is set.
+  if (process.env.ADMIN_EMAIL && process.env.ADMIN_PASSWORD) {
+    return login(process.env.ADMIN_EMAIL, process.env.ADMIN_PASSWORD);
+  }
   let cred;
   try {
     cred = JSON.parse(readFileSync(`${process.env.HOME}/.listgem_admin_cred`, 'utf8'));
   } catch {
-    throw new Error('No credential: set ADMIN_TOKEN or write ~/.listgem_admin_cred');
+    throw new Error('No credential: set ADMIN_TOKEN, or ADMIN_EMAIL + ADMIN_PASSWORD, or write ~/.listgem_admin_cred');
   }
   if (cred.token) {
     const claims = JSON.parse(Buffer.from(cred.token.split('.')[1], 'base64url').toString());
@@ -53,13 +69,7 @@ async function credential() {
     }
     return cred.token;
   }
-  const res = await fetch(`${API}/auth/login`, {
-    method: 'POST',
-    headers: { 'content-type': 'application/json' },
-    body: JSON.stringify({ email: cred.email, password: cred.password }),
-  });
-  if (!res.ok) throw new Error(`login ${res.status}`);
-  return (await res.json()).token;
+  return login(cred.email, cred.password);
 }
 
 const token = await credential();


### PR DESCRIPTION
Handing § 39 to a QA tester exposed two gaps that aren't about the concierge surface at all.

## This repo has no CI

297 tests, and nothing runs them. That's a suite you find out about during a release — and it bit today: I committed a PR with lint failing because `echo "lint=$?"` swallowed the exit status. CI would have caught it in ninety seconds.

`ci.yml` runs lint, typecheck, test and build on push to `main` and on every PR. Node 20, matching the jsdom pin.

## The probe needed a clone, a Node install, and a developer

§ 39 opens by telling the tester to run `npm run check:contract`. For a non-technical tester that's a wall at step zero.

`contract-check.yml` runs it **every three hours and on manual dispatch**, so a verdict is a button or a glance at the last run.

The schedule is the point, not a convenience. The failure this exists for comes from **another repo**: when the API removed `raw_text` from the preview payload — a correct change — the live site rendered unresolved rows as bare row numbers until the matching frontend change merged. No CI in either repo runs on the other's deploy. Nothing would have noticed but a person looking.

## Two decisions worth reading

**Email + password, not a token.** A JWT lasts 24 hours, so a token in a repo secret would report a stale credential as a contract failure by the next morning. That's the monitor lying, and a lying monitor gets muted — which costs more than not having one. The script also refuses outright on an expired credential rather than reporting the resulting auth bounces as failures.

**Three hours is a guess.** Each run creates one scratch pitch and takes it down, so a tighter cadence buys detection latency and pays in archived rows. Tune it once there's evidence.

## Before it does anything

Needs `ADMIN_EMAIL` and `ADMIN_PASSWORD` repo secrets. Until they exist the scheduled job will fail on the credential — visibly, which is the right failure.

`npm test` (297), lint, typecheck, build pass.