### PR TITLE
Rendered e2e for the concierge surface

### DIFF
--- a/.github/workflows/e2e.yml
+++ b/.github/workflows/e2e.yml
@@ -1,0 +1,32 @@
+name: E2E — concierge
+
+# Runs against the deployed portal and site, and creates production data:
+# a scratch pitch per test, taken down in teardown. On merge only, never on
+# every PR — the same rule the website repo's prod-data specs follow.
+on:
+  push:
+    branches: [main]
+  workflow_dispatch:
+
+jobs:
+  e2e:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+          cache: npm
+      - run: npm ci
+      - run: npx playwright install --with-deps chromium
+      - name: Run the specs
+        env:
+          ADMIN_EMAIL: ${{ secrets.ADMIN_EMAIL }}
+          ADMIN_PASSWORD: ${{ secrets.ADMIN_PASSWORD }}
+        run: npm run test:e2e
+      - uses: actions/upload-artifact@v4
+        if: failure()
+        with:
+          name: playwright-traces
+          path: test-results/
+          retention-days: 7

--- a/e2e/fixtures.js
+++ b/e2e/fixtures.js
@@ -1,0 +1,76 @@
+import { test as base, expect } from '@playwright/test';
+import { readFileSync } from 'node:fs';
+
+export const API = process.env.API_URL || 'https://listgem-platform-production.up.railway.app';
+export const SITE = process.env.SITE_URL || 'https://listgem-website.netlify.app';
+
+export async function api(method, path, body, token) {
+  const res = await fetch(`${API}${path}`, {
+    method,
+    headers: { 'content-type': 'application/json', ...(token ? { authorization: `Bearer ${token}` } : {}) },
+    body: body === undefined ? undefined : JSON.stringify(body),
+  });
+  const text = await res.text();
+  const data = text ? JSON.parse(text) : {};
+  if (!res.ok) throw new Error(`${method} ${path} → ${res.status}: ${text.slice(0, 200)}`);
+  return data;
+}
+
+async function adminToken() {
+  if (process.env.ADMIN_TOKEN) return process.env.ADMIN_TOKEN;
+  if (process.env.ADMIN_EMAIL && process.env.ADMIN_PASSWORD) {
+    const { token } = await api('POST', '/auth/login', {
+      email: process.env.ADMIN_EMAIL, password: process.env.ADMIN_PASSWORD,
+    });
+    return token;
+  }
+  const cred = JSON.parse(readFileSync(`${process.env.HOME}/.listgem_admin_cred`, 'utf8'));
+  if (cred.token) return cred.token;
+  return (await api('POST', '/auth/login', { email: cred.email, password: cred.password })).token;
+}
+
+/**
+ * Fixtures for the concierge surface.
+ *
+ * `admin` seeds the portal's session the way AuthContext does, so a navigation
+ * lands logged in. `pitch` creates a scratch pitch and takes it down after —
+ * takedown purges contact, revokes both tokens and archives, in one call.
+ *
+ * Everything here runs against production, because that is the only
+ * environment. Nothing is left behind that a run can avoid leaving.
+ */
+export const test = base.extend({
+  admin: async ({ page }, use) => {
+    const token = await adminToken();
+    const claims = JSON.parse(Buffer.from(token.split('.')[1], 'base64url').toString());
+    if (claims.exp && claims.exp * 1000 < Date.now()) {
+      throw new Error('admin credential expired — the run would report auth bounces as failures');
+    }
+    const user = { user_id: claims.user_id || claims.sub, email: claims.email, username: 'admin', is_admin: true };
+
+    // Before any app code runs, or RequireAuth bounces to /login first.
+    await page.addInitScript(([t, u]) => {
+      sessionStorage.setItem('token', t);
+      sessionStorage.setItem('user', u);
+    }, [token, JSON.stringify(user)]);
+
+    await use({ token, user });
+  },
+
+  pitch: async ({ admin }, use) => {
+    const made = await api('POST', '/pitches', {
+      target_name: 'E2E — automated',
+      proposed_title: 'E2E — automated',
+      thing_type: 'Movie',
+      notes: 'Created by e2e. Taken down in teardown.',
+    }, admin.token);
+    const pitchId = made.pitch.pitch_id;
+
+    await use({ pitchId, token: admin.token });
+
+    await api('POST', `/pitches/${pitchId}/takedown`, { reason: 'e2e teardown' }, admin.token)
+      .catch(() => {});
+  },
+});
+
+export { expect };

--- a/e2e/playwright.config.js
+++ b/e2e/playwright.config.js
@@ -1,0 +1,24 @@
+import { defineConfig } from '@playwright/test';
+
+/**
+ * These specs run against the deployed portal, not a dev server: what they are
+ * checking is what an operator and a target actually see, and every defect they
+ * exist for survived a green unit suite.
+ */
+export default defineConfig({
+  testDir: './specs',
+  // Resolution goes out to TMDB and back; a paste of four rows takes ~15s.
+  timeout: 120_000,
+  expect: { timeout: 15_000 },
+  // Serial: each spec creates a scratch pitch against production, and parallel
+  // runs would interleave scratch data on a shared board for no gain.
+  workers: 1,
+  fullyParallel: false,
+  retries: process.env.CI ? 1 : 0,
+  reporter: process.env.CI ? [['github'], ['list']] : [['list']],
+  use: {
+    baseURL: process.env.ADMIN_URL || 'https://listgem-admin.netlify.app',
+    trace: 'retain-on-failure',
+    screenshot: 'only-on-failure',
+  },
+});

--- a/e2e/specs/builder-guards.spec.js
+++ b/e2e/specs/builder-guards.spec.js
@@ -1,0 +1,77 @@
+import { test, expect } from '../fixtures.js';
+
+/**
+ * The builder's guards, asserted on the rendered page.
+ *
+ * Each of these has a unit test already. They are here because the unit tests
+ * were green while the rendered page was wrong: candidate art read from a field
+ * that is null in production, a note field whose label contradicted where the
+ * data went, a rail asking an operator to finish a list the API rejects edits
+ * to. Shape was never the problem.
+ */
+test.describe('builder guards', () => {
+  test('a pasted table resolves to titles, and the heading row is dropped', async ({ page, pitch }) => {
+    await page.goto(`/concierge/${pitch.pitchId}`);
+
+    await page.locator('textarea').first().fill([
+      'Rank Film Year Worldwide gross Ref',
+      '1 Jaws 1975 $495,201,848 [13][14]',
+      '2 The Exorcist 1973 $430,872,776 [19][20]',
+      '3 Get Out 2017 $255,751,443 [75][76]',
+    ].join('\n'));
+    await page.getByRole('button', { name: /parse & resolve/i }).click();
+
+    // The films resolve by title, not by the pasted line.
+    await expect(page.getByRole('cell', { name: /^Jaws/ })).toBeVisible();
+    await expect(page.locator('tbody')).toContainText('The Exorcist');
+
+    // The heading is recognised and struck through, not sent to the matcher.
+    await expect(page.locator('tbody tr').first()).toContainText('Rank Film Year');
+    await expect(page.getByText(/1 dropped/i)).toBeVisible();
+  });
+
+  test('two rows on one film name both rows and block the save', async ({ page, pitch }) => {
+    await page.goto(`/concierge/${pitch.pitchId}`);
+
+    await page.locator('textarea').first().fill(['Persona (1966)', 'Persona', 'Jaws (1975)'].join('\n'));
+    await page.getByRole('button', { name: /parse & resolve/i }).click();
+
+    // Naming only the later row sent an operator to delete the correct one, so
+    // the strip names both and refuses to say which is wrong.
+    const strip = page.getByText(/both point at/i);
+    await expect(strip).toBeVisible();
+    await expect(strip).toContainText('Rows 1 and 2');
+    await expect(page.getByRole('button', { name: /^save items/i })).toBeDisabled();
+
+    await page.getByRole('button', { name: /^Drop row 2$/ }).click();
+    await expect(page.getByRole('button', { name: /^save items/i })).toBeEnabled();
+  });
+
+  test('candidates carry cover art', async ({ page, pitch }) => {
+    // Read from image_url alone this renders empty boxes for every candidate:
+    // that field is null on all 11,952 Movie things, and the art is at
+    // metadata.poster_url.
+    await page.goto(`/concierge/${pitch.pitchId}`);
+    await page.locator('textarea').first().fill('Hannibal (2001)');
+    await page.getByRole('button', { name: /parse & resolve/i }).click();
+    await expect(page.locator('tbody tr')).toHaveCount(1);
+
+    await page.locator('tbody tr').first().click();
+    await page.getByRole('button', { name: /^search$/i }).click();
+
+    const art = page.locator('img[src*="image.tmdb.org"], img[src*="/images/proxy"]');
+    await expect(art.first()).toBeVisible();
+  });
+
+  test('the two note fields say who reads them', async ({ page, pitch }) => {
+    // One of these used to be labelled "internal" and was copied onto the
+    // target's own list.
+    await page.goto(`/concierge/${pitch.pitchId}`);
+    await page.locator('textarea').first().fill('Jaws (1975)');
+    await page.getByRole('button', { name: /parse & resolve/i }).click();
+    await page.locator('tbody tr').first().click();
+
+    await expect(page.getByText(/Note on this item/i)).toContainText(/target sees this/i);
+    await expect(page.getByText(/^Internal note/i)).toContainText(/copied nowhere/i);
+  });
+});

--- a/e2e/specs/target-surfaces.spec.js
+++ b/e2e/specs/target-surfaces.spec.js
@@ -1,0 +1,89 @@
+import { test, expect, api, SITE } from '../fixtures.js';
+
+/**
+ * What a target sees. These are the surfaces where a defect costs us a person
+ * rather than a bug report, and every one of them shipped a leak this month:
+ * the invite showed nothing, the preview rendered the operator's own working
+ * line, and a claimed list arrived carrying an issue number.
+ *
+ * Built through the API rather than the UI — the builder is covered by
+ * builder-guards.spec.js, and what is under test here is the output.
+ */
+const ITEMS = [
+  {
+    raw_text: 'Persona (1966) \u{1F1F8}\u{1F1EA} 8.6/10',
+    display_text: 'Persona',
+    thing_id: 'movie_persona_1966_4d7b531f',
+    resolution_status: 'resolved',
+    note: 'The one that made me want to make films.',
+    internal_note: 'INTERNAL-PROBE check the 1966 Bergman, not the 2011 anime',
+  },
+  {
+    raw_text: 'The Emigrants + The New Land (1971, 1972) \u{1F1F8}\u{1F1EA} 8.6/10',
+    display_text: 'The Emigrants + The New Land',
+    thing_id: null,
+    resolution_status: 'ambiguous',
+    note: null,
+    internal_note: null,
+  },
+];
+
+async function stocked(pitch) {
+  await api('PUT', `/pitches/${pitch.pitchId}/items`, { items: ITEMS }, pitch.token);
+  return api('POST', `/pitches/${pitch.pitchId}/tokens`, {}, pitch.token);
+}
+
+test.describe('what the target sees', () => {
+  test('the preview shows titles, never the operator\'s line', async ({ page, pitch }) => {
+    const { preview_token } = await stocked(pitch);
+    await page.goto(`${SITE}/pitch/${preview_token}`);
+
+    await expect(page.getByText('Persona').first()).toBeVisible();
+
+    // An unresolved row belongs on the list — it is part of what they compiled
+    // — but labelled, never with the pasted line, and never as a bare number.
+    await expect(page.getByText('The Emigrants + The New Land')).toBeVisible();
+    await expect(page.getByText(/8\.6\/10/)).toHaveCount(0);
+    await expect(page.getByText(/\(1971, 1972\)/)).toHaveCount(0);
+
+    // The note written for them appears; the working note does not.
+    await expect(page.getByText(/made me want to make films/)).toBeVisible();
+    await expect(page.getByText(/INTERNAL-PROBE/)).toHaveCount(0);
+
+    // A forwardable link must not escalate into a capability.
+    await expect(page.getByRole('button', { name: /claim/i })).toHaveCount(0);
+  });
+
+  test('the invite shows the list rather than describing it', async ({ page, pitch }) => {
+    const { invite_token } = await stocked(pitch);
+    await api('POST', `/pitches/${pitch.pitchId}/status`, { status: 'pitched' }, pitch.token);
+
+    await page.goto(`${SITE}/signup?invite=${invite_token}`);
+
+    await expect(page.getByText(/a list is waiting for you/i)).toBeVisible();
+    await expect(page.getByText('E2E — automated').first()).toBeVisible();
+    // Being asked to make an account for a list you cannot see is the thing
+    // this surface exists to avoid.
+    await expect(page.getByText('Persona')).toBeVisible();
+    await expect(page.getByText(/INTERNAL-PROBE/)).toHaveCount(0);
+  });
+
+  test('a draft invite is refused, and the count is what will land', async ({ pitch }) => {
+    const { invite_token } = await stocked(pitch);
+
+    // Still a draft: the server refuses, which is why the portal warns before
+    // an operator ever copies the link.
+    const draft = await fetch(`${process.env.API_URL || 'https://listgem-platform-production.up.railway.app'}/pitches/invite/${invite_token}`);
+    expect(draft.status).toBe(410);
+    expect((await draft.json()).reason).toBe('not_claimable_from_draft');
+
+    await api('POST', `/pitches/${pitch.pitchId}/status`, { status: 'pitched' }, pitch.token);
+    const live = await api('GET', `/pitches/invite/${invite_token}`);
+
+    // Two items on the pitch, one of them unresolved: one will land. Promising
+    // the draft's row count would be a promise the claim quietly breaks.
+    expect(live.valid).toBe(true);
+    expect(live.item_count).toBe(1);
+    expect(live.sample.map(s => s.title)).toEqual(['Persona']);
+  });
+});

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -27,6 +27,16 @@ export default defineConfig([
       'no-unused-vars': ['error', { varsIgnorePattern: '^[A-Z_]' }],
     },
   },
+  // Node, not a browser: the e2e harness and the contract probe run outside the
+  // app. The react-hooks rule also misfires here — Playwright's fixtures take a
+  // callback named `use`, which is a parameter, not a hook.
+  {
+    files: ['e2e/**/*.js', 'scripts/**/*.mjs'],
+    languageOptions: { globals: globals.node },
+    rules: {
+      'react-hooks/rules-of-hooks': 'off',
+    },
+  },
   // The pages stay plain JSX; .ts is for the modules carrying a real contract
   // (the concierge state machine and payload shapes). Without this block they
   // would silently stop being linted.

--- a/package-lock.json
+++ b/package-lock.json
@@ -16,6 +16,7 @@
       },
       "devDependencies": {
         "@eslint/js": "^9.39.4",
+        "@playwright/test": "^1.62.1",
         "@tailwindcss/vite": "^4.2.2",
         "@testing-library/dom": "^10.4.1",
         "@testing-library/react": "^16.3.2",
@@ -1161,6 +1162,22 @@
       "dependencies": {
         "@jridgewell/resolve-uri": "^3.1.0",
         "@jridgewell/sourcemap-codec": "^1.4.14"
+      }
+    },
+    "node_modules/@playwright/test": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/@playwright/test/-/test-1.62.1.tgz",
+      "integrity": "sha512-DTcUc8qii+cpHvtOwggMtBRMjKZHXYWdw8syRYu2vtzuq4Wxphqq4NfCs5Zt44L6mA8rfDfj+PHnxFc/FeK6mQ==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
       }
     },
     "node_modules/@rolldown/pluginutils": {
@@ -4324,6 +4341,53 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/playwright": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright/-/playwright-1.62.1.tgz",
+      "integrity": "sha512-0M+L3LAD8/nm554LOla9Ayx0j0tmFZ0FBcoQ7F1VuVHpM/XpiC8RcDzBQB8W5+hA8L22THxELzeF+2WcUzvcLg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "playwright-core": "1.62.1"
+      },
+      "bin": {
+        "playwright": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "optionalDependencies": {
+        "fsevents": "2.3.2"
+      }
+    },
+    "node_modules/playwright-core": {
+      "version": "1.62.1",
+      "resolved": "https://registry.npmjs.org/playwright-core/-/playwright-core-1.62.1.tgz",
+      "integrity": "sha512-wPYSwEBJY9GHraISXqyqtx0na0LpO3XEX7jNDhntbex7tzUS7kLnZsOlFruFJB4Hi/rhDMjXGqHewDZ68nYZVw==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "bin": {
+        "playwright-core": "cli.js"
+      },
+      "engines": {
+        "node": ">=20"
+      }
+    },
+    "node_modules/playwright/node_modules/fsevents": {
+      "version": "2.3.2",
+      "resolved": "https://registry.npmjs.org/fsevents/-/fsevents-2.3.2.tgz",
+      "integrity": "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==",
+      "dev": true,
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ],
+      "engines": {
+        "node": "^8.16.0 || ^10.6.0 || >=11.0.0"
       }
     },
     "node_modules/postcss": {

--- a/package.json
+++ b/package.json
@@ -11,7 +11,9 @@
     "test": "vitest run",
     "test:watch": "vitest",
     "preview": "vite preview",
-    "check:contract": "node scripts/contract-check.mjs"
+    "check:contract": "node scripts/contract-check.mjs",
+    "test:e2e": "playwright test --config=e2e/playwright.config.js",
+    "test:e2e:headed": "playwright test --config=e2e/playwright.config.js --headed"
   },
   "dependencies": {
     "@tanstack/react-query": "^5.95.2",
@@ -22,6 +24,7 @@
   },
   "devDependencies": {
     "@eslint/js": "^9.39.4",
+    "@playwright/test": "^1.62.1",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/dom": "^10.4.1",
     "@testing-library/react": "^16.3.2",


### PR DESCRIPTION
The automation half of the QA/UAT split. Seven Playwright specs against the deployed portal and site.

## What they cover

**Builder guards, as an operator sees them** — a pasted table resolving to titles with the heading row dropped; two rows on one film naming *both* rows and blocking the save; candidate cover art; the two note fields labelled by who reads them.

**The preview and invite, as a target sees them** — titles never the operator's line, an unresolved row labelled rather than blank, the target-visible note present and the internal one absent, no claim affordance on a forwardable link, and an invite that reports what will actually land rather than the draft's row count.

Between them that's most of `QA-SCRIPT.md` § 39's mechanical checkboxes — which is the point. A checkbox a machine can assert shouldn't be asked of a person, and what's left for § 39 is only judgement.

## Every one of these has a unit test already

They're here because the unit tests were green while the rendered page was wrong: art read from a field that's null in production, a note field whose label contradicted where the data went, a rail asking an operator to finish a list the API rejects edits to. Shape was never the problem.

## Negative assertions were checked, not trusted

`toHaveCount(0)` passes when the locator is wrong or the page never loaded — a vacuous green. One was inverted against content known to be present and confirmed to fail before being restored. Every negative also sits beside a positive assertion on the same page, so a blank render can't satisfy it.

## Production data

Prod is the only environment, so each test creates real rows. Following the website repo's precedent for its prod-data specs:

- **on merge to `main` only**, never on every PR
- a scratch pitch per test, taken down in teardown — which runs even when the test fails
- scratch records named `E2E —` so a sweep can find any orphan

## Note on the first commit

This branch's first commit said these had never passed, and that was true — the local credential expired before the first run reached authentication. They now pass in 27 seconds, and the earlier failures were entirely the credential guard doing its job.

`npm test` (297), lint, typecheck, build pass; `npm run test:e2e` 7/7.